### PR TITLE
Minor CSS edit for dashboard cards

### DIFF
--- a/hackathon_site/dashboard/frontend/src/components/dashboard/DashCard/DashCard.module.scss
+++ b/hackathon_site/dashboard/frontend/src/components/dashboard/DashCard/DashCard.module.scss
@@ -15,7 +15,7 @@
         }
         svg {
             color: color(grey);
-            margin-left: 25px;
+            margin-left: 15px;
         }
     }
 }

--- a/hackathon_site/dashboard/frontend/src/components/dashboard/TeamCard/TeamCard.js
+++ b/hackathon_site/dashboard/frontend/src/components/dashboard/TeamCard/TeamCard.js
@@ -23,7 +23,7 @@ const TeamCard = ({ members, teamCode, handleEditTeam }) => {
                 ))}
 
                 <Container className={styles.lastRow}>
-                    <Button className={styles.ButtonColor} onClick={handleEditTeam}>
+                    <Button color="primary" onClick={handleEditTeam}>
                         Edit
                     </Button>
                 </Container>

--- a/hackathon_site/dashboard/frontend/src/components/dashboard/TeamCard/TeamCard.module.scss
+++ b/hackathon_site/dashboard/frontend/src/components/dashboard/TeamCard/TeamCard.module.scss
@@ -5,14 +5,11 @@
     padding: 8px 0px;
     overflow-x: hidden;
     .name {
-        padding: 12px 50px 12px 20px;
+        padding: 12px 20px;
     }
 }
 .lastRow {
     display: flex;
     justify-content: flex-end;
     padding-top: 6px;
-}
-.ButtonColor {
-    color: color(primary);
 }

--- a/hackathon_site/dashboard/frontend/src/components/dashboard/TeamCard/__snapshots__/TeamCard.test.js.snap
+++ b/hackathon_site/dashboard/frontend/src/components/dashboard/TeamCard/__snapshots__/TeamCard.test.js.snap
@@ -50,7 +50,7 @@ exports[`TeamCard render 1`] = `
       class="MuiContainer-root lastRow MuiContainer-maxWidthLg"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-text ButtonColor"
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary"
         tabindex="0"
         type="button"
       >


### PR DESCRIPTION
- Fix padding-right for DashCard and EditTeam (I added this back when we had horizontal scroll but now it no longer makes sense)
- Edit team card: give button color=“primary”