### PR TITLE
Update current user endpoint to use user serializer

### DIFF
--- a/hackathon_site/event/serializers.py
+++ b/hackathon_site/event/serializers.py
@@ -10,25 +10,23 @@ class GroupSerializer(serializers.ModelSerializer):
         fields = ("id", "name")
 
 
-class UserSerializer(serializers.ModelSerializer):
-    groups = GroupSerializer(many=True, read_only=True)
-
-    class Meta:
-        model = User
-        fields = ("id", "first_name", "last_name", "email", "groups")
-
-
 class ProfileSerializer(serializers.ModelSerializer):
-    user = UserSerializer(read_only=True)
-
     class Meta:
         model = Profile
         fields = (
             "id",
-            "user",
             "status",
             "id_provided",
             "attended",
             "acknowledge_rules",
             "e_signature",
         )
+
+
+class UserSerializer(serializers.ModelSerializer):
+    profile = ProfileSerializer(read_only=True)
+    groups = GroupSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = User
+        fields = ("id", "first_name", "last_name", "email", "profile", "groups")

--- a/hackathon_site/event/test_api.py
+++ b/hackathon_site/event/test_api.py
@@ -32,22 +32,29 @@ class CurrentUserTestCase(APITestCase):
     def test_user_has_no_profile(self):
         self.profile.delete()
         self._login()
-        response = self.client.get(self.view)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    def test_correct_response(self):
         expected_response = {
-            "id": self.profile.id,
-            "user": {
-                **{
-                    attr: getattr(self.user, attr)
-                    for attr in ("id", "first_name", "last_name", "email")
-                },
-                "groups": [{"id": self.group.id, "name": self.group.name,}],
-            },
             **{
+                attr: getattr(self.user, attr)
+                for attr in ("id", "first_name", "last_name", "email")
+            },
+            "profile": None,
+            "groups": [{"id": self.group.id, "name": self.group.name}],
+        }
+        response = self.client.get(self.view)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(expected_response, data)
+
+    def test_user_has_profile(self):
+        expected_response = {
+            **{
+                attr: getattr(self.user, attr)
+                for attr in ("id", "first_name", "last_name", "email")
+            },
+            "profile": {
                 attr: getattr(self.profile, attr)
                 for attr in (
+                    "id",
                     "status",
                     "id_provided",
                     "attended",
@@ -55,6 +62,7 @@ class CurrentUserTestCase(APITestCase):
                     "e_signature",
                 )
             },
+            "groups": [{"id": self.group.id, "name": self.group.name}],
         }
         self._login()
         response = self.client.get(self.view)

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -1,7 +1,7 @@
 from rest_framework import generics, mixins
 
-from event.models import Profile
-from event.serializers import ProfileSerializer
+from event.models import User
+from event.serializers import UserSerializer
 
 
 class CurrentUserAPIView(generics.GenericAPIView, mixins.RetrieveModelMixin):
@@ -9,10 +9,13 @@ class CurrentUserAPIView(generics.GenericAPIView, mixins.RetrieveModelMixin):
     View to handle API interaction with the current user's Profile
     """
 
-    serializer_class = ProfileSerializer
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
 
     def get_object(self):
-        return generics.get_object_or_404(Profile.objects.all(), user=self.request.user)
+        queryset = self.get_queryset()
+
+        return generics.get_object_or_404(queryset, id=self.request.user.id)
 
     def get(self, request, *args, **kwargs):
         """

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -9,7 +9,7 @@ class CurrentUserAPIView(generics.GenericAPIView, mixins.RetrieveModelMixin):
     View to handle API interaction with the current user's Profile
     """
 
-    queryset = User.objects.all()
+    queryset = User.objects.select_related("profile")
     serializer_class = UserSerializer
 
     def get_object(self):


### PR DESCRIPTION
Resolves #91 

Updates the /api/event/users/user/ endpoint to return the current user, with nested profile, rather than the other way around. This way users without profiles (tech team, admins) can still use this endpoint.