### PR TITLE
Add django-debug-toolbar

### DIFF
--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -71,6 +71,10 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
+if DEBUG:
+    INSTALLED_APPS += ["debug_toolbar"]
+    MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware"] + MIDDLEWARE
+
 ROOT_URLCONF = "hackathon_site.urls"
 
 TEMPLATES = [

--- a/hackathon_site/hackathon_site/urls.py
+++ b/hackathon_site/hackathon_site/urls.py
@@ -18,11 +18,8 @@ from django.urls import path, include
 from django.conf.urls import url
 from django.conf import settings
 
-from rest_framework import permissions
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
-
-PUBLIC = bool(settings.DEBUG)
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -30,7 +27,7 @@ schema_view = get_schema_view(
         default_version="v1",
         description="API Endpoint Visualization for Hardware Hackathon",
     ),
-    public=PUBLIC,
+    public=bool(settings.DEBUG),
 )
 
 urlpatterns = [
@@ -42,3 +39,9 @@ urlpatterns = [
         name="schema-swagger-ui",
     ),
 ]
+
+
+if settings.DEBUG:
+    import debug_toolbar
+
+    urlpatterns = [path("__debug__/", include(debug_toolbar.urls))] + urlpatterns

--- a/hackathon_site/requirements.txt
+++ b/hackathon_site/requirements.txt
@@ -10,6 +10,7 @@ coreschema==0.0.4
 dj-rest-auth==1.0.6
 Django==3.0.7
 django-cors-headers==3.3.0
+django-debug-toolbar==2.2
 djangorestframework==3.11.0
 drf-yasg==1.17.1
 idna==2.9


### PR DESCRIPTION
Resolves #93 

Adds django-debug-toolbar, which is great for debugging and especially queryset optimization when writing API endpoints, since it shows you what SQL queries are ran, and points out which ones are duplicates of the same type of query.

You'll need to run `python manage.py collectstatic` to make this work.

Also, this uses django's regular templating engine in the background. If we switch to Jinja, we'll need to set the admin site and debug_toolbar to use django's templating engine.