### PR TITLE
Add dates for registration and event into the settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A website template for hackathons run by [IEEE University of Toronto Student Bra
     * [Forking](#forking)
     * [From the Template (Recommended)](#from-the-template)
     * [Copy the Repository](#copy-the-repository)
+- [Customization](#customization)
 
 ## Requirements
 - Python 3.8 or higher
@@ -260,3 +261,10 @@ This approach is very similar to using the template, but you lose the "generated
     ```
    
 6. Make a PR on your repo to merge `update-from-upstream-template` into your base branch.
+
+## Customization
+This project was designed to be generic and customizable. At minimum, you will want to update templates to include your event's name and logo, but you may customize them to whatever degree you wish. See [file structure](#file-structure) for more details about templates.
+
+Core event settings and constants, such as cutoff dates, are kept at the bottom of the [settings](hackathon_site/hackathon_site/settings/__init__.py) file. These settings can be imported and used in any view, form, or in general any other python file. See the [Django docs on settings](https://docs.djangoproject.com/en/3.1/topics/settings/#using-settings-in-python-code) to read more about how to use them.
+
+For convenience, some constants have been passed into the context of all Jinja templates by default, so they can be used right away. See the [Jinja2 config file](hackathon_site/hackathon_site/jinja2.py) for full details.

--- a/hackathon_site/event/jinja2/event/landing.html
+++ b/hackathon_site/event/jinja2/event/landing.html
@@ -1,5 +1,13 @@
 {% extends "event/base.html" %}
 
+{% block head_extends %}
+<script>
+    const registrationOpenDate = new Date("{{ localtime(registration_open_date).strftime('%b %-d, %Y, %H:%M:%S') }}");
+    const registrationCloseDate = new Date("{{ localtime(registration_close_date).strftime('%b %-d, %Y, %H:%M:%S') }}");
+    const eventStartDate = new Date("{{ localtime(event_start_date).strftime('%b %-d, %Y, %H:%M:%S') }}");
+</script>
+{% endblock %}
+
 {% block nav %}
 <ul class="right hide-on-med-and-down">
     <li><a href="#about">About</a></li>
@@ -37,7 +45,10 @@
             </div>
             <div class="row">
                 <h5>Location</h5>
-                <h5>XX XX-XX, 20XX</h5>
+                <h5>
+                    {# Update this logic if your event ends in a different month or year #}
+                    {{ localtime(event_start_date).strftime("%B %d") }}-{{ localtime(event_end_date).strftime("%d, %Y") }}
+                </h5>
             </div>
             <div class="row">
                 <a class="btn-large waves-effect waves-light colorBtn">Login/Apply</a>
@@ -301,7 +312,8 @@
     </div>
     <div class="footer-copyright center">
         <div class="container">
-            Copyright © 2020-2021 IEEE University of Toronto Student Branch
+            Copyright © {% if localtime(event_end_date).year > 2020 %}2020-{% endif %}
+            {{ localtime(event_end_date).strftime("%Y") }} IEEE University of Toronto Student Branch
         </div>
     </div>
 </footer>

--- a/hackathon_site/event/static/event/js/landing.js
+++ b/hackathon_site/event/static/event/js/landing.js
@@ -17,28 +17,23 @@ $(document).ready(function () {
 
     // Countdown stuff
 
-    // Registration open and close date, and event date
-    const regOpenDate = new Date("Sep 1, 2020 00:00:00").getTime();
-    const regCloseDate = new Date("Sep 30, 2020 00:00:00").getTime();
-    const eventDate = new Date("Oct 31, 2020 00:00:00").getTime();
-
-    const now = new Date().getTime();
+    const now = new Date();
     let countDownDate;
 
     // Set the title based off what it's counting down to
-    if (regOpenDate >= now) {
-        countDownDate = regOpenDate;
+    if (registrationOpenDate >= now) {
+        countDownDate = registrationOpenDate;
         $("#countdownTitle").html("Registration Opens In");
-    } else if (regCloseDate >= now) {
-        countDownDate = regCloseDate;
+    } else if (registrationCloseDate >= now) {
+        countDownDate = registrationCloseDate;
         $("#countdownTitle").html("Registration Closes In");
-    } else if (eventDate >= now) {
-        countDownDate = eventDate;
+    } else if (eventStartDate >= now) {
+        countDownDate = eventStartDate;
         $("#countdownTitle").html("Event Starts In");
     }
 
     // Delete the entire countdown if event start date has passed
-    if (eventDate < now) {
+    if (eventStartDate < now) {
         $("#countdown").remove();
         $("#aboutText").removeClass("l7");
     } else {
@@ -48,7 +43,7 @@ $(document).ready(function () {
 });
 
 function setCounter(countDownDate) {
-    const now = new Date().getTime();
+    const now = new Date();
     const distance = countDownDate - now;
     const days = Math.ceil(distance / (1000 * 60 * 60 * 24));
 

--- a/hackathon_site/hackathon_site/jinja2.py
+++ b/hackathon_site/hackathon_site/jinja2.py
@@ -1,10 +1,24 @@
 from django.contrib.staticfiles.storage import staticfiles_storage
+from django.conf import settings
 from django.urls import reverse
+from django.utils.timezone import template_localtime
 
 from jinja2 import Environment
 
 
 def environment(**options):
     env = Environment(**options)
-    env.globals.update({"static": staticfiles_storage.url, "url": reverse})
+    env.globals.update(
+        {
+            # Functions
+            "static": staticfiles_storage.url,
+            "url": reverse,
+            "localtime": template_localtime,
+            # Variables
+            "registration_open_date": settings.REGISTRATION_OPEN_DATE,
+            "registration_close_date": settings.REGISTRATION_CLOSE_DATE,
+            "event_start_date": settings.EVENT_START_DATE,
+            "event_end_date": settings.EVENT_END_DATE,
+        }
+    )
     return env

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -10,7 +10,9 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
+from datetime import datetime
 import os
+import pytz
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -162,3 +164,9 @@ SWAGGER_SETTINGS = {"DEFAULT_MODEL_RENDERING": "example", "DEEP_LINKING": True}
 
 STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
+
+# Event specific settings
+REGISTRATION_OPEN_DATE = datetime(2020, 9, 1, tzinfo=pytz.timezone(TIME_ZONE))
+REGISTRATION_CLOSE_DATE = datetime(2020, 9, 30, tzinfo=pytz.timezone(TIME_ZONE))
+EVENT_START_DATE = datetime(2020, 10, 10, 10, 0, 0, tzinfo=pytz.timezone(TIME_ZONE))
+EVENT_END_DATE = datetime(2020, 10, 11, 17, 0, 0, tzinfo=pytz.timezone(TIME_ZONE))


### PR DESCRIPTION
Resolves #129 

- Adds registration open and close and event start and end to the settings file
- Adds them to the global Jinja2 context, so they're always available in templates
- Updates the landing page to use them instead of dates being hard-coded into HTML or JS