### PR TITLE
Login page

### DIFF
--- a/hackathon_site/event/jinja2/event/application.html
+++ b/hackathon_site/event/jinja2/event/application.html
@@ -101,7 +101,6 @@
             </label>
         </p>
     </div>    
-</form>
 <br />
 <div class="container center ">
     You cannot edit this afterwards!

--- a/hackathon_site/event/jinja2/event/form_base.html
+++ b/hackathon_site/event/jinja2/event/form_base.html
@@ -6,11 +6,15 @@
         <div class="loginDiv z-depth-3 row">
             <div class="row col s12 flexColCenter {% if self.form_img() %}l7 m8{% endif %}">
                 <h1 class="formH1">{% block form_title %}{% endblock %}</h1>
-                <form class="col s12">
+                <form class="col s12"
+                    action="{{ form_action }}"
+                    method="{{ form_method if form_method else "post" }}"
+                >
+                    {{ csrf_input }}
                     {% block form_inputs %}{% endblock %}
+                    <br />
+                    {% block form_button %}{% endblock %}
                 </form>
-
-                {% block form_button %}{% endblock %}
                 <br />
                 {% block form_bottom %}{% endblock %}
             </div>

--- a/hackathon_site/event/jinja2/event/login.html
+++ b/hackathon_site/event/jinja2/event/login.html
@@ -1,25 +1,61 @@
 {% extends "event/form_base.html" %}
 
 {% block form_title %}Login{% endblock %}
-{% block form_button %}<button href="#" class="btn-small waves-effect waves-light secondaryColor colorBtn center">Login</button>{% endblock %}
 
 {% block form_img %}<img src="{{ static('event/images/landing.svg') }}" alt="Login image"/>{% endblock %}
-               
+
+{% set form_action=url("event:login") %}
+
 {% block form_inputs %}
 <div class="row" style="margin-bottom: 0;">
     <div class="input-field col s12" style="margin-bottom: 0;">
-        <input id="email" type="email" class="validate">
-        <label for="email">email</label>
-        <span class="helper-text" data-error="Please put in a valid email"></span>
-    </div>
-    </div>
-<div class="row" style="margin-bottom: 0;">
-    <div class="input-field col s12">
-        <input id="password" type="password" class="validate">
-        <label for="password">password</label>
-        <span class="helper-text" data-error="No combination with this email/password"></span>
+        <input
+            id="{{ form.username.id_for_label }}"
+            name="username"
+            type="email"
+            class="{% if form.username.errors %}invalid{% endif %}"
+            value="{{ form.username.value() }}"
+        >
+        <label for="{{ form.username.id_for_label }}">Email</label>
+        {% if form.username.errors %}
+            <span class="formFieldError">
+            {% for error in form.username.errors %}
+                {{ error }}
+                <br />
+            {% endfor %}
+            </span>
+        {% endif %}
+
     </div>
 </div>
+<div class="row" style="margin-bottom: 0;">
+    <div class="input-field col s12">
+        <input
+            id="{{ form.password.id_for_label }}"
+            name="password"
+            type="password"
+            class="{% if form.password.errors %}invalid{% endif %}"
+        >
+        <label for="{{ form.password.id_for_label }}">Password</label>
+        {% if form.password.errors %}
+            <span class="formFieldError">
+            {% for error in form.password.errors %}
+                {{ error }}
+                <br />
+            {% endfor %}
+            </span>
+        {% endif %}
+    </div>
+</div>
+{% if form.non_field_errors %}
+    {% for error in form.non_field_errors() %}
+        {{ error }}
+    {% endfor %}
+{% endif %}
+{% endblock %}
+
+{% block form_button %}
+<button type="submit" class="btn-small waves-effect waves-light secondaryColor colorBtn center">Login</button>
 {% endblock %}
 
 {% block form_bottom %}

--- a/hackathon_site/event/jinja2/event/login.html
+++ b/hackathon_site/event/jinja2/event/login.html
@@ -14,7 +14,7 @@
             name="username"
             type="email"
             class="{% if form.username.errors %}invalid{% endif %}"
-            value="{{ form.username.value() }}"
+            value="{{ form.username.value() or ""}}"
         >
         <label for="{{ form.username.id_for_label }}">Email</label>
         {% if form.username.errors %}
@@ -55,7 +55,7 @@
 {% endblock %}
 
 {% block form_button %}
-<button type="submit" class="btn-small waves-effect waves-light secondaryColor colorBtn center">Login</button>
+<button type="submit" id="login-submit" class="btn-small waves-effect waves-light secondaryColor colorBtn center">Login</button>
 {% endblock %}
 
 {% block form_bottom %}

--- a/hackathon_site/event/jinja2/event/signup.html
+++ b/hackathon_site/event/jinja2/event/signup.html
@@ -28,7 +28,6 @@
         <label for="password">confirm password</label>
         <span class="helper-text" data-error="Passwords do not match"></span>
     </div>
-</form>
 {% endblock %}
 
 {% block form_bottom %}

--- a/hackathon_site/event/static/event/styles/scss/styles.scss
+++ b/hackathon_site/event/static/event/styles/scss/styles.scss
@@ -306,6 +306,12 @@ strong {
     &Checkbox span {
         color: color(font);
     }
+
+    &FieldError {
+        font-size: 12px;
+        color: #f44336;
+        display: block;
+    }
 }
 // End of form stuff
 

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -36,6 +36,16 @@ class IndexViewTestCase(TestCase):
 
 
 class LogInViewTestCase(SetupUserMixin, TestCase):
+    """
+    Tests for the login template.
+
+    This view uses django.contrib.auth.forms.AuthenticationForm, so no direct
+    form testing is required.
+
+    Ideally, selenium should be used for a full test of the view UI.
+    For practicality reasons, tests for templates with forms are limited to
+    POSTing raw data at this time.
+    """
     def setUp(self):
         super().setUp()
         self.view = reverse("event:login")

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -46,6 +46,7 @@ class LogInViewTestCase(SetupUserMixin, TestCase):
     For practicality reasons, tests for templates with forms are limited to
     POSTing raw data at this time.
     """
+
     def setUp(self):
         super().setUp()
         self.view = reverse("event:login")

--- a/hackathon_site/event/urls.py
+++ b/hackathon_site/event/urls.py
@@ -1,6 +1,14 @@
+from django.contrib.auth import views as auth_views
 from django.urls import path
 from event.views import IndexView
 
 app_name = "event"
 
-urlpatterns = [path("", IndexView.as_view(), name="index")]
+urlpatterns = [
+    path("", IndexView.as_view(), name="index"),
+    path(
+        "accounts/login/",
+        auth_views.LoginView.as_view(template_name="event/login.html"),
+        name="login",
+    ),
+]


### PR DESCRIPTION
Resolves #56. Hooks up the login template to Django's default login view, now accessible at /accounts/login.

When login succeeds, you'll be redirected to /accounts/profile, which currently doesn't exist. That's fine for now.

Ideally, selenium should be used for a full test of the view UI. For practicality reasons, tests for templates with forms are limited to    POSTing raw data at this time.
