### PR TITLE
Connect Application to the Dashboard

### DIFF
--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -13,7 +13,7 @@
 
             {% if application is none %}
                 <h4 class="formH2">Complete your application</h4>
-                <p>We'll collect your contact information</p>
+                <p><strong>Status</strong>: Incomplete</p>
                 <a
                     href="{{ url("registration:application") }}"
                     class="btn-small waves-effect waves-light secondaryColor colorBtn center"
@@ -22,6 +22,7 @@
                 </a>
             {% else %}
                 <h4 class="formH2">Your application has been submitted!</h4>
+                <p><strong>Status</strong>: Submitted</p>
                 <p>We're in the process of reviewing your application. Watch for an email from {{ from_email }}, and check back here for updates.</p>
             {% endif %}
 

--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -9,22 +9,38 @@
 <div class="container">
     <div class="section">
         <div class="borderTopDiv z-depth-3">
-            <h1 class="formH1 col s12">Dashboard</h1>
+            <h1 class="formH1">Dashboard</h1>
 
-            <h4 class="formH2 col s12">Complete your application</h4>
-            <p><strong>Status</strong>: incompleted</p>
-            <a href="#" class="btn-small waves-effect waves-light secondaryColor colorBtn center">Get started</a>
+            {% if application is none %}
+                <h4 class="formH2">Complete your application</h4>
+                <p>We'll collect your contact information</p>
+                <a
+                    href="{{ url("registration:application") }}"
+                    class="btn-small waves-effect waves-light secondaryColor colorBtn center"
+                >
+                    Get started
+                </a>
+            {% else %}
+                <h4 class="formH2">Your application has been submitted!</h4>
+                <p>We're in the process of reviewing your application. Watch for an email from {{ from_email }}, and check back here for updates.</p>
+            {% endif %}
+
         </div>
 
         <div class="borderTopDiv z-depth-3">
-            <h4 class="formH2 col s12">Apply as team</h4>
-
+            <h4 class="formH2">Apply as team</h4>
             <p>Have friends you want to work with? Create a team with up to 4 people and we’ll review your applications together. Enter your team code or make a new one and share with your members.</p>
-            <p><strong>You must complete your application before you can form a team.</strong></p>
+            {% if application is none %}
+                  <p><strong>You must complete your application before you can form a team. Return here once you've submitted your application.</strong></p>
+            {% else %}
+            {% endif %}
+
+
+
         </div>
 
         <div class="borderTopDiv z-depth-3">
-            <h4 class="formH2 col s12">Application FAQs</h4>
+            <h4 class="formH2">Application FAQs</h4>
 
             <p class="faqQuestion">When can I expect to hear back?</p>
             <p class="faqAnswer">Decisions will be sent out in 2 rounds, tentatively scheduled for MONTH XX and XX.</p>

--- a/hackathon_site/event/jinja2/event/landing.html
+++ b/hackathon_site/event/jinja2/event/landing.html
@@ -34,7 +34,11 @@
             </div>
             <div class="row">
                 {% if request.user.is_authenticated %}
-                    <a href="{{ url("event:dashboard") }}" class="btn-large waves-effect waves-light colorBtn">Continue Application</a>
+                    {% if application is none %}
+                        <a href="{{ url("registration:application") }}" class="btn-large waves-effect waves-light colorBtn">Continue Application</a>
+                    {% else %}
+                        <a href="{{ url("event:dashboard") }}" class="btn-large waves-effect waves-light colorBtn">Go to Dashboard</a>
+                    {% endif %}
                 {% else %}
                     <a href="{{ url("registration:signup") }}" class="btn-large waves-effect waves-light colorBtn">Apply</a>
                 {% endif %}

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -5,6 +5,18 @@ from django.views.generic import TemplateView
 class IndexView(TemplateView):
     template_name = "event/landing.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["user"] = self.request.user
+        context["application"] = getattr(self.request.user, "application", None)
+        return context
+
 
 class DashboardView(LoginRequiredMixin, TemplateView):
     template_name = "event/dashboard_base.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["user"] = self.request.user
+        context["application"] = getattr(self.request.user, "application", None)
+        return context

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -17,6 +17,8 @@ import os
 from pathlib import Path
 import pytz
 
+from django.urls import reverse_lazy
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
 
@@ -109,6 +111,8 @@ TEMPLATES = [
 FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 
 WSGI_APPLICATION = "hackathon_site.wsgi.application"
+
+LOGIN_REDIRECT_URL = reverse_lazy("event:dashboard")
 
 
 # Database

--- a/hackathon_site/registration/test_forms.py
+++ b/hackathon_site/registration/test_forms.py
@@ -79,8 +79,8 @@ class ApplicationFormTestCase(SetupUserMixin, TestCase):
         super().setUp()
         self.data = {
             "birthday": date(2020, 9, 8),
-            "gender": "male",
-            "ethnicity": "caucasian",
+            "gender": "no-answer",
+            "ethnicity": "no-answer",
             "phone_number": "1234567890",
             "school": "UofT",
             "study_level": "other",


### PR DESCRIPTION
Resolves #153.

## Changes
- Logins now redirect to the dashboard by default
- A link to the application will appear on the dashboard if the user has not finished their application

## Steps to QA
- Login
- Look at dashboard, see link to application. There should also be a note to apply before joining a team.
- Apply
- Go back to dashboard, see message telling the user to wait for a response. The team joining section will be implemented in another PR.

The CSS is somewhat gross, @lisa-sa-li has generously offered her expertise in that department.


