### PR TITLE
Close Applications after Registration Closes

### DIFF
--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -16,7 +16,7 @@
                     <h4 class="formH2">Applications have closed</h4>
                     <p>Unfortunately, the deadline to apply for {{ event_name }} was {{ localtime(registration_close_date).strftime("%B %-d, %Y") }}.</p>
                     <br />
-                    <p>If you have any questions or concerns, please <a href="mailto:{{ email }}" class="hoverLink primaryText">contact us</a>.</p>
+                    <p>If you have any questions or concerns, please <a href="mailto:{{ contact_email }}" class="hoverLink primaryText">contact us</a>.</p>
                 {% else %}
                     <h4 class="formH2">Complete your application</h4>
                     <p><strong>Status</strong>: Incomplete</p>

--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -12,14 +12,21 @@
             <h1 class="formH1">Dashboard</h1>
 
             {% if application is none %}
-                <h4 class="formH2">Complete your application</h4>
-                <p><strong>Status</strong>: Incomplete</p>
-                <a
-                    href="{{ url("registration:application") }}"
-                    class="btn-small waves-effect waves-light secondaryColor colorBtn center"
-                >
-                    Get started
-                </a>
+                {% if not registration_open %}
+                    <h4 class="formH2">Applications have closed</h4>
+                    <p>Unfortunately, the deadline to apply for {{ event_name }} was {{ localtime(registration_close_date).strftime("%B %-d, %Y") }}.</p>
+                    <br />
+                    <p>If you have any questions or concerns, please <a href="mailto:{{ email }}" class="hoverLink primaryText">contact us</a>.</p>
+                {% else %}
+                    <h4 class="formH2">Complete your application</h4>
+                    <p><strong>Status</strong>: Incomplete</p>
+                    <a
+                        href="{{ url("registration:application") }}"
+                        class="btn-small waves-effect waves-light secondaryColor colorBtn center"
+                    >
+                        Get started
+                    </a>
+                {% endif %}
             {% else %}
                 <h4 class="formH2">Your application has been submitted!</h4>
                 <p><strong>Status</strong>: Submitted</p>
@@ -28,6 +35,7 @@
 
         </div>
 
+        {% if registration_open or application is not none %}
         <div class="borderTopDiv z-depth-3">
             <h4 class="formH2">Apply as team</h4>
             <p>Have friends you want to work with? Create a team with up to 4 people and we’ll review your applications together.</p>
@@ -35,13 +43,15 @@
                   <p><strong>You must complete your application before you can form a team. Return here once you've submitted your application.</strong></p>
             {% else %}
                 <p>Your team code is: <strong>{{ application.team.team_code }}</strong>.</p>
-                {% set num_members = application.team.applications.count() %}
-                <p>
-                    Spots remaining on your team: <strong>{{ application.team.MAX_MEMBERS - num_members }}</strong>.
-                    {% if join_team_form and num_members < application.team.MAX_MEMBERS%}
-                        Share your team code with your teammates, or join their team instead.
-                    {% endif %}
-                </p>
+                {% if registration_open %}
+                    {% set num_members = application.team.applications.count() %}
+                    <p>
+                        Spots remaining on your team: <strong>{{ application.team.MAX_MEMBERS - num_members }}</strong>.
+                        {% if join_team_form and num_members < application.team.MAX_MEMBERS%}
+                            Share your team code with your teammates, or join their team instead.
+                        {% endif %}
+                    </p>
+                {% endif %}
                 <h5>Team Members</h5>
                 <ul>
                     {% for application in application.team.applications.all() %}
@@ -79,10 +89,8 @@
                 {% endif %}
 
             {% endif %}
-
-
-
         </div>
+        {% endif %}
 
         <div class="borderTopDiv z-depth-3">
             <h4 class="formH2">Application FAQs</h4>

--- a/hackathon_site/event/jinja2/event/landing.html
+++ b/hackathon_site/event/jinja2/event/landing.html
@@ -34,12 +34,12 @@
             </div>
             <div class="row">
                 {% if request.user.is_authenticated %}
-                    {% if application is none %}
+                    {% if application is none and registration_open %}
                         <a href="{{ url("registration:application") }}" class="btn-large waves-effect waves-light colorBtn">Continue Application</a>
                     {% else %}
                         <a href="{{ url("event:dashboard") }}" class="btn-large waves-effect waves-light colorBtn">Go to Dashboard</a>
                     {% endif %}
-                {% else %}
+                {% elif registration_open %}
                     <a href="{{ url("registration:signup") }}" class="btn-large waves-effect waves-light colorBtn">Apply</a>
                 {% endif %}
             </div>

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from rest_framework import status
 from django.core import mail
@@ -129,6 +129,22 @@ class DashboardTestCase(SetupUserMixin, TestCase):
 
         # Join team form appears
         self.assertContains(response, "Join a Different Team")
+
+    @override_settings(REGISTRATION_OPEN=False)
+    def test_not_applied_applications_closed(self):
+        self._login()
+        response = self.client.get(self.view)
+        self.assertContains(response, "Applications have closed")
+        self.assertNotContains(response, "Complete your application")
+        self.assertNotContains(response, "Apply as a team")
+
+    @override_settings(REGISTRATION_OPEN=False)
+    def test_shows_submitted_application_after_applications_closed(self):
+        self._login()
+        self._apply()
+        response = self.client.get(self.view)
+        self.assertContains(response, "Your application has been submitted!")
+        self.assertNotContains(response, "Spots remaining on your team")
 
     def test_join_team(self):
         """

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -46,6 +46,8 @@ class IndexViewTestCase(SetupUserMixin, TestCase):
         response = self.client.get(self.view)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertContains(response, "Login")
+        self.assertContains(response, "Apply")
+        self.assertContains(response, reverse("registration:signup"))
 
     def test_logout_button_renders_when_logged_in(self):
         self._login()
@@ -53,11 +55,18 @@ class IndexViewTestCase(SetupUserMixin, TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertContains(response, "Logout")
 
-    def test_links_to_application_when_not_applied(self):
+    def test_links_to_application_when_not_applied_and_registration_open(self):
         self._login()
         response = self.client.get(self.view)
         self.assertContains(response, "Continue Application")
         self.assertContains(response, reverse("registration:application"))
+
+    @override_settings(REGISTRATION_OPEN=False)
+    def test_links_to_dashboard_when_not_applied_and_registration_closed(self):
+        self._login()
+        response = self.client.get(self.view)
+        self.assertContains(response, "Go to Dashboard")
+        self.assertContains(response, reverse("event:dashboard"))
 
     def test_links_to_dashboard_when_applied(self):
         self._login()
@@ -65,6 +74,11 @@ class IndexViewTestCase(SetupUserMixin, TestCase):
         response = self.client.get(self.view)
         self.assertContains(response, "Go to Dashboard")
         self.assertContains(response, reverse("event:dashboard"))
+
+    @override_settings(REGISTRATION_OPEN=False)
+    def test_no_apply_button_when_registration_closed(self):
+        response = self.client.get(self.view)
+        self.assertNotContains(response, reverse("registration:signup"))
 
 
 class DashboardTestCase(SetupUserMixin, TestCase):

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -15,6 +15,12 @@ class IndexView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+
+        # In testing, the @override_settings decorator doesn't run in time for the jinja2
+        # environment. Set the registration_open context here again to make sure the
+        # overridden settings are reflected in the template
+        context["registration_open"] = settings.REGISTRATION_OPEN
+
         context["user"] = self.request.user
         context["application"] = getattr(self.request.user, "application", None)
         return context

--- a/hackathon_site/hackathon_site/jinja2.py
+++ b/hackathon_site/hackathon_site/jinja2.py
@@ -18,6 +18,7 @@ def environment(**options):
             "event_name": settings.HACKATHON_NAME,
             "registration_open_date": settings.REGISTRATION_OPEN_DATE,
             "registration_close_date": settings.REGISTRATION_CLOSE_DATE,
+            "registration_open": settings.REGISTRATION_OPEN,
             "event_start_date": settings.EVENT_START_DATE,
             "event_end_date": settings.EVENT_END_DATE,
             "from_email": settings.DEFAULT_FROM_EMAIL,

--- a/hackathon_site/hackathon_site/settings/ci.py
+++ b/hackathon_site/hackathon_site/settings/ci.py
@@ -28,3 +28,9 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
 if not os.path.isdir(MEDIA_ROOT):
     os.makedirs(MEDIA_ROOT)
+
+# In testing, default registration to be always open (so tests don't
+# fail when the date rolls after the close date). Tests that rely on
+# registration being closed should use the ``django.test.override_settings``
+# decorator.
+REGISTRATION_OPEN = True

--- a/hackathon_site/registration/forms.py
+++ b/hackathon_site/registration/forms.py
@@ -164,15 +164,23 @@ class JoinTeamForm(forms.Form):
         self.label_suffix = ""
         self.error_css_class = "invalid"
 
+    def clean(self):
+        if not settings.REGISTRATION_OPEN:
+            raise forms.ValidationError(
+                _("You cannot change teams after registration has closed."), code="registration_closed"
+            )
+
+        return super().clean()
+
     def clean_team_code(self):
         team_code = self.cleaned_data["team_code"]
 
         try:
             team = Team.objects.get(team_code=team_code)
         except Team.DoesNotExist:
-            raise forms.ValidationError(f"Team {team_code} does not exist.")
+            raise forms.ValidationError(_(f"Team {team_code} does not exist."))
 
         if team.applications.count() >= Team.MAX_MEMBERS:
-            raise forms.ValidationError(f"Team {team_code} is full.")
+            raise forms.ValidationError(_(f"Team {team_code} is full."))
 
         return team_code

--- a/hackathon_site/registration/forms.py
+++ b/hackathon_site/registration/forms.py
@@ -167,7 +167,8 @@ class JoinTeamForm(forms.Form):
     def clean(self):
         if not settings.REGISTRATION_OPEN:
             raise forms.ValidationError(
-                _("You cannot change teams after registration has closed."), code="registration_closed"
+                _("You cannot change teams after registration has closed."),
+                code="registration_closed",
             )
 
         return super().clean()

--- a/hackathon_site/registration/forms.py
+++ b/hackathon_site/registration/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.contrib.auth import get_user_model
+from django.conf import settings
 from django.contrib.auth.forms import UserCreationForm
 from django.utils.translation import gettext_lazy as _
 from django_registration import validators
@@ -130,10 +130,15 @@ class ApplicationForm(forms.ModelForm):
         self.fields["data_agree"].required = True
 
     def clean(self):
+        if not settings.REGISTRATION_OPEN:
+            raise forms.ValidationError(
+                _("Registration has closed."), code="registration_closed"
+            )
+
         cleaned_data = super().clean()
         if hasattr(self.user, "application"):
             raise forms.ValidationError(
-                _("User has already submitted an application"), code="invalid"
+                _("User has already submitted an application."), code="invalid"
             )
         return cleaned_data
 

--- a/hackathon_site/registration/test_forms.py
+++ b/hackathon_site/registration/test_forms.py
@@ -262,3 +262,13 @@ class JoinTeamFormTestCase(SetupUserMixin, TestCase):
         self._apply_as_user(self.user, self.team)
         form = JoinTeamForm(data={"team_code": self.team.team_code})
         self.assertTrue(form.is_valid())
+
+    @override_settings(REGISTRATION_OPEN=False)
+    def test_registration_has_closed(self):
+        self._apply_as_user(self.user, self.team)
+        form = JoinTeamForm(data={"team_code": self.team.team_code})
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            "You cannot change teams after registration has closed.",
+            form.non_field_errors(),
+        )

--- a/hackathon_site/registration/test_forms.py
+++ b/hackathon_site/registration/test_forms.py
@@ -2,7 +2,7 @@ from datetime import date
 from io import BytesIO
 
 from django.core.files.uploadedfile import InMemoryUploadedFile
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django_registration import validators
 
 from hackathon_site.tests import SetupUserMixin
@@ -143,7 +143,7 @@ class ApplicationFormTestCase(SetupUserMixin, TestCase):
         form = self._build_form()
         self.assertFalse(form.is_valid())
         self.assertIn(
-            "User has already submitted an application", form.non_field_errors()
+            "User has already submitted an application.", form.non_field_errors()
         )
 
     def test_saving_adds_team_and_user(self):
@@ -233,6 +233,12 @@ class ApplicationFormTestCase(SetupUserMixin, TestCase):
             "File must be no bigger than 20.0\xa0MB. Currently 20.0\xa0MB.",
             form.errors["resume"],
         )
+
+    @override_settings(REGISTRATION_OPEN=False)
+    def test_registration_has_closed(self):
+        form = self._build_form()
+        self.assertFalse(form.is_valid())
+        self.assertIn("Registration has closed.", form.non_field_errors())
 
 
 class JoinTeamFormTestCase(SetupUserMixin, TestCase):

--- a/hackathon_site/registration/views.py
+++ b/hackathon_site/registration/views.py
@@ -121,9 +121,16 @@ class LeaveTeamView(LoginRequiredMixin, View):
     """
 
     def leave_team(self, request):
+        if not settings.REGISTRATION_OPEN:
+            return HttpResponseBadRequest(
+                "You cannot change teams after registration has closed.".encode(
+                    encoding="utf-8"
+                )
+            )
+
         if not hasattr(request.user, "application"):
             return HttpResponseBadRequest(
-                "You have not submitted an application".encode(encoding="utf-8")
+                "You have not submitted an application.".encode(encoding="utf-8")
             )
 
         application = self.request.user.application


### PR DESCRIPTION
Resolves #160.

## Changes
- Registration defaults to always open in testing
- Don't allow applications after registration has closed
- Don't allow changing or leaving teams after registration has closed
- "Don't allow" means don't let the forms make the change, and don't show it on the dashboard.

## Steps to QA
- Change the `REGISTRATION_OPEN` setting (or the `REGISTRATION_CLOSE_DATE` to some time in the past) and try the above actions.