### PR TITLE
Add logout redirect url to settings

### DIFF
--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -113,6 +113,7 @@ FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 WSGI_APPLICATION = "hackathon_site.wsgi.application"
 
 LOGIN_REDIRECT_URL = reverse_lazy("event:dashboard")
+LOGOUT_REDIRECT_URL = reverse_lazy("event:index")
 
 
 # Database


### PR DESCRIPTION
This is not noticeable when running locally, because it defaults to `/`. However when running under a subfolder, logging out ends up booting you off the event site.