### PR TITLE
Fix Registration Open Behaviour

### DIFF
--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -12,7 +12,7 @@
             <h1 class="formH1">Dashboard</h1>
 
             {% if application is none %}
-                {% if not registration_open %}
+                {% if not is_registration_open() %}
                     <h2 class="formH2">Applications have closed</h2>
                     <p>Unfortunately, the deadline to apply for {{ event_name }} was {{ localtime(registration_close_date).strftime("%B %-d, %Y") }}.</p>
                     <br />
@@ -37,7 +37,7 @@
             {% endif %}
         </div>
 
-        {% if registration_open or application is not none %}
+        {% if is_registration_open() or application is not none %}
         <div class="borderTopDiv z-depth-3">
             <h2 class="formH2">Apply as a team</h2>
             <p>Have friends you want to work with? Create a team with up to 4 people and we’ll review your applications together.</p>
@@ -46,7 +46,7 @@
                   <p><strong>You must complete your application before you can form a team. Return here once you've submitted your application.</strong></p>
             {% else %}
                 <p>Your team code is: <strong>{{ application.team.team_code }}</strong>.</p>
-                {% if registration_open %}
+                {% if is_registration_open() %}
                     {% set num_members = application.team.applications.count() %}
                     <p>
                         {% if join_team_form and num_members < application.team.MAX_MEMBERS%}

--- a/hackathon_site/event/jinja2/event/landing.html
+++ b/hackathon_site/event/jinja2/event/landing.html
@@ -36,12 +36,12 @@
             </div>
             <div class="row">
                 {% if request.user.is_authenticated %}
-                    {% if application is none and registration_open %}
+                    {% if application is none and is_registration_open() %}
                         <a href="{{ url("registration:application") }}" class="btn-large waves-effect waves-light colorBtn">Continue Application</a>
                     {% else %}
                         <a href="{{ url("event:dashboard") }}" class="btn-large waves-effect waves-light colorBtn">Go to Dashboard</a>
                     {% endif %}
-                {% elif registration_open %}
+                {% elif is_registration_open() %}
                     <a href="{{ url("registration:signup") }}" class="btn-large waves-effect waves-light colorBtn">Apply</a>
                 {% endif %}
             </div>

--- a/hackathon_site/event/jinja2/event/login.html
+++ b/hackathon_site/event/jinja2/event/login.html
@@ -8,6 +8,10 @@
 
 {% set form_action=url("event:login") %}
 
+{% if next %}
+    {% set form_action = form_action + "?next=" + next %}
+{% endif %}
+
 {% block form_inputs %}
 <div class="input-field row col s12" style="margin-bottom: 0;">
     <input

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -279,7 +279,7 @@ class LogOutViewTestCase(SetupUserMixin, TestCase):
 
     def test_logout_get(self):
         response = self.client.get(self.view)
-        self.assertRedirects(response, "/")
+        self.assertRedirects(response, settings.LOGOUT_REDIRECT_URL)
 
 
 class PasswordChangeTestCase(SetupUserMixin, TestCase):

--- a/hackathon_site/event/urls.py
+++ b/hackathon_site/event/urls.py
@@ -12,9 +12,7 @@ urlpatterns = [
         auth_views.LoginView.as_view(template_name="event/login.html"),
         name="login",
     ),
-    path(
-        "accounts/logout/", auth_views.LogoutView.as_view(next_page="/"), name="logout",
-    ),
+    path("accounts/logout/", auth_views.LogoutView.as_view(), name="logout",),
     path("dashboard/", DashboardView.as_view(), name="dashboard"),
     path(
         "accounts/change_password/",

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.shortcuts import redirect
@@ -6,6 +5,7 @@ from django.urls import reverse_lazy
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
 
+from hackathon_site.utils import is_registration_open
 from registration.forms import JoinTeamForm
 from registration.models import Team
 
@@ -15,11 +15,6 @@ class IndexView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-
-        # In testing, the @override_settings decorator doesn't run in time for the jinja2
-        # environment. Set the registration_open context here again to make sure the
-        # overridden settings are reflected in the template
-        context["registration_open"] = settings.REGISTRATION_OPEN
 
         context["user"] = self.request.user
         context["application"] = getattr(self.request.user, "application", None)
@@ -46,7 +41,7 @@ class DashboardView(LoginRequiredMixin, FormView):
         if not hasattr(self.request.user, "application"):
             return None
 
-        if settings.REGISTRATION_OPEN:
+        if is_registration_open():
             return JoinTeamForm(**self.get_form_kwargs())
 
         # Once RSVP form is implemented, more logic to choose it should go here
@@ -74,11 +69,6 @@ class DashboardView(LoginRequiredMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-
-        # In testing, the @override_settings decorator doesn't run in time for the jinja2
-        # environment. Set the registration_open context here again to make sure the
-        # overridden settings are reflected in the template
-        context["registration_open"] = settings.REGISTRATION_OPEN
 
         context["user"] = self.request.user
         context["application"] = getattr(self.request.user, "application", None)

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -16,6 +16,11 @@ class IndexView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
+        # In testing, the @patch decorator doesn't run in time for the jinja2
+        # environment. Set the is_registration_open context here again to make sure the
+        # it is reflected in templates for testing
+        context["is_registration_open"] = is_registration_open
+
         context["user"] = self.request.user
         context["application"] = getattr(self.request.user, "application", None)
         return context
@@ -69,6 +74,11 @@ class DashboardView(LoginRequiredMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+
+        # In testing, the @patch decorator doesn't run in time for the jinja2
+        # environment. Set the is_registration_open context here again to make sure the
+        # it is reflected in templates for testing
+        context["is_registration_open"] = is_registration_open
 
         context["user"] = self.request.user
         context["application"] = getattr(self.request.user, "application", None)

--- a/hackathon_site/hackathon_site/jinja2.py
+++ b/hackathon_site/hackathon_site/jinja2.py
@@ -2,8 +2,9 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from django.conf import settings
 from django.urls import reverse
 from django.utils.timezone import template_localtime
-
 from jinja2 import Environment
+
+from hackathon_site.utils import is_registration_open
 
 
 def environment(**options):
@@ -14,11 +15,11 @@ def environment(**options):
             "static": staticfiles_storage.url,
             "url": reverse,
             "localtime": template_localtime,
+            "is_registration_open": is_registration_open,
             # Variables
             "event_name": settings.HACKATHON_NAME,
             "registration_open_date": settings.REGISTRATION_OPEN_DATE,
             "registration_close_date": settings.REGISTRATION_CLOSE_DATE,
-            "registration_open": settings.REGISTRATION_OPEN,
             "event_start_date": settings.EVENT_START_DATE,
             "event_end_date": settings.EVENT_END_DATE,
             "from_email": settings.DEFAULT_FROM_EMAIL,

--- a/hackathon_site/hackathon_site/jinja2.py
+++ b/hackathon_site/hackathon_site/jinja2.py
@@ -6,6 +6,11 @@ from jinja2 import Environment
 
 from hackathon_site.utils import is_registration_open
 
+# In testing, nothing in this file can be overwritten using the
+# @patch or @override_settings decorators, because it is evaluated before
+# the test methods. If you have tests that rely on these values, explicitly
+# set them in the context of your views.
+
 
 def environment(**options):
     env = Environment(**options)

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -115,7 +115,7 @@ FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 WSGI_APPLICATION = "hackathon_site.wsgi.application"
 
 LOGIN_REDIRECT_URL = reverse_lazy("event:dashboard")
-LOGOUT_REDIRECT_URL = reverse_lazy("registration:signup")
+LOGOUT_REDIRECT_URL = reverse_lazy("event:index")
 
 
 # Database

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -32,6 +32,8 @@ SECRET_KEY = os.environ["SECRET_KEY"]
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(int(os.environ.get("DEBUG", 0)))
 
+IN_TESTING = False  # Overwritten by hackathon_site.settings.ci
+
 if DEBUG:
     ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
     INTERNAL_IPS = ["localhost", "127.0.0.1"]

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -114,7 +114,8 @@ FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 
 WSGI_APPLICATION = "hackathon_site.wsgi.application"
 
-LOGIN_REDIRECT_URL = reverse_lazy("event:dashboard")
+LOGIN_REDIRECT_URL = "event:dashboard"
+LOGOUT_REDIRECT_URL = "event:index"
 
 
 # Database

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -114,8 +114,8 @@ FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 
 WSGI_APPLICATION = "hackathon_site.wsgi.application"
 
-LOGIN_REDIRECT_URL = "event:dashboard"
-LOGOUT_REDIRECT_URL = "event:index"
+LOGIN_REDIRECT_URL = reverse_lazy("event:dashboard")
+LOGOUT_REDIRECT_URL = reverse_lazy("registration:signup")
 
 
 # Database

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -200,7 +200,7 @@ HACKATHON_NAME = "CoolHacks"
 DEFAULT_FROM_EMAIL = "webmaster@localhost"
 CONTACT_EMAIL = DEFAULT_FROM_EMAIL
 
-REGISTRATION_OPEN_DATE = datetime(2020, 9, 14, 21, 0, 0, tzinfo=TZ_INFO)
+REGISTRATION_OPEN_DATE = datetime(2020, 9, 1, tzinfo=TZ_INFO)
 REGISTRATION_CLOSE_DATE = datetime(2020, 9, 30, tzinfo=TZ_INFO)
 EVENT_START_DATE = datetime(2020, 10, 10, 10, 0, 0, tzinfo=TZ_INFO)
 EVENT_END_DATE = datetime(2020, 10, 11, 17, 0, 0, tzinfo=TZ_INFO)

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -203,6 +203,4 @@ EVENT_START_DATE = datetime(2020, 10, 10, 10, 0, 0, tzinfo=TZ_INFO)
 EVENT_END_DATE = datetime(2020, 10, 11, 17, 0, 0, tzinfo=TZ_INFO)
 
 # Registration settings
-now = datetime.now(TZ_INFO)
 ACCOUNT_ACTIVATION_DAYS = 7
-REGISTRATION_OPEN = REGISTRATION_OPEN_DATE <= now < REGISTRATION_CLOSE_DATE

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -197,7 +197,7 @@ HACKATHON_NAME = "CoolHacks"
 DEFAULT_FROM_EMAIL = "webmaster@localhost"
 CONTACT_EMAIL = DEFAULT_FROM_EMAIL
 
-REGISTRATION_OPEN_DATE = datetime(2020, 9, 1, tzinfo=TZ_INFO)
+REGISTRATION_OPEN_DATE = datetime(2020, 9, 14, 21, 0, 0, tzinfo=TZ_INFO)
 REGISTRATION_CLOSE_DATE = datetime(2020, 9, 30, tzinfo=TZ_INFO)
 EVENT_START_DATE = datetime(2020, 10, 10, 10, 0, 0, tzinfo=TZ_INFO)
 EVENT_END_DATE = datetime(2020, 10, 11, 17, 0, 0, tzinfo=TZ_INFO)

--- a/hackathon_site/hackathon_site/settings/ci.py
+++ b/hackathon_site/hackathon_site/settings/ci.py
@@ -20,6 +20,9 @@ and by running your code before you merge it.
 """
 from hackathon_site.settings import *
 
+# Convenient for some methods to test, since DEBUG=0 in testing
+IN_TESTING = True
+
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
 
 # For testing, make the media root a local folder to avoid
@@ -28,9 +31,3 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
 if not os.path.isdir(MEDIA_ROOT):
     os.makedirs(MEDIA_ROOT)
-
-# In testing, default registration to be always open (so tests don't
-# fail when the date rolls after the close date). Tests that rely on
-# registration being closed should use the ``django.test.override_settings``
-# decorator.
-REGISTRATION_OPEN = True

--- a/hackathon_site/hackathon_site/utils.py
+++ b/hackathon_site/hackathon_site/utils.py
@@ -7,6 +7,9 @@ def is_registration_open():
     """
     Determine whether registration is currently open
     """
+    if settings.IN_TESTING:
+        # So tests don't rely on the date, default to true
+        return True
 
     # datetime.now() returns the system native time, so this assumes that the system timezone
     # is configured to match TIME_ZONE. We then make the datetime object timezone-aware.

--- a/hackathon_site/hackathon_site/utils.py
+++ b/hackathon_site/hackathon_site/utils.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+from django.conf import settings
+
+
+def is_registration_open():
+    """
+    Determine whether registration is currently open
+    """
+
+    # datetime.now() returns the system native time, so this assumes that the system timezone
+    # is configured to match TIME_ZONE. We then make the datetime object timezone-aware.
+    now = datetime.now().replace(tzinfo=settings.TZ_INFO)
+    return settings.REGISTRATION_OPEN_DATE <= now < settings.REGISTRATION_CLOSE_DATE

--- a/hackathon_site/registration/forms.py
+++ b/hackathon_site/registration/forms.py
@@ -4,6 +4,7 @@ from django.contrib.auth.forms import UserCreationForm
 from django.utils.translation import gettext_lazy as _
 from django_registration import validators
 
+from hackathon_site.utils import is_registration_open
 from registration.models import Application, Team, User
 from registration.widgets import MaterialFileInput
 
@@ -136,7 +137,7 @@ class ApplicationForm(forms.ModelForm):
         self.fields["data_agree"].required = True
 
     def clean(self):
-        if not settings.REGISTRATION_OPEN:
+        if not is_registration_open():
             raise forms.ValidationError(
                 _("Registration has closed."), code="registration_closed"
             )
@@ -171,7 +172,7 @@ class JoinTeamForm(forms.Form):
         self.error_css_class = "invalid"
 
     def clean(self):
-        if not settings.REGISTRATION_OPEN:
+        if not is_registration_open():
             raise forms.ValidationError(
                 _("You cannot change teams after registration has closed."),
                 code="registration_closed",

--- a/hackathon_site/registration/test_forms.py
+++ b/hackathon_site/registration/test_forms.py
@@ -1,8 +1,9 @@
 from datetime import date
 from io import BytesIO
+from unittest.mock import patch
 
 from django.core.files.uploadedfile import InMemoryUploadedFile
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django_registration import validators
 
 from hackathon_site.tests import SetupUserMixin
@@ -234,8 +235,9 @@ class ApplicationFormTestCase(SetupUserMixin, TestCase):
             form.errors["resume"],
         )
 
-    @override_settings(REGISTRATION_OPEN=False)
-    def test_registration_has_closed(self):
+    @patch("registration.forms.is_registration_open")
+    def test_registration_has_closed(self, mock_is_registration_open):
+        mock_is_registration_open.return_value = False
         form = self._build_form()
         self.assertFalse(form.is_valid())
         self.assertIn("Registration has closed.", form.non_field_errors())
@@ -263,8 +265,9 @@ class JoinTeamFormTestCase(SetupUserMixin, TestCase):
         form = JoinTeamForm(data={"team_code": self.team.team_code})
         self.assertTrue(form.is_valid())
 
-    @override_settings(REGISTRATION_OPEN=False)
-    def test_registration_has_closed(self):
+    @patch("registration.forms.is_registration_open")
+    def test_registration_has_closed(self, mock_is_registration_open):
+        mock_is_registration_open.return_value = False
         self._apply_as_user(self.user, self.team)
         form = JoinTeamForm(data={"team_code": self.team.team_code})
         self.assertFalse(form.is_valid())

--- a/hackathon_site/registration/test_views.py
+++ b/hackathon_site/registration/test_views.py
@@ -1,8 +1,9 @@
 from datetime import date
+from unittest.mock import patch
 
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
 
@@ -210,8 +211,9 @@ class LeaveTeamViewTestCase(SetupUserMixin, TestCase):
         self.assertNotEqual(self.user.application.team.id, initial_team_id)
         self.assertEqual(Team.objects.count(), 2)
 
-    @override_settings(REGISTRATION_OPEN=False)
-    def test_registration_has_closed(self):
+    @patch("registration.views.is_registration_open")
+    def test_registration_has_closed(self, mock_is_registration_open):
+        mock_is_registration_open.return_value = False
         self._login()
         response = self.client.get(self.view)
         self.assertContains(

--- a/hackathon_site/registration/views.py
+++ b/hackathon_site/registration/views.py
@@ -124,7 +124,7 @@ class LeaveTeamView(LoginRequiredMixin, View):
     """
 
     def leave_team(self, request):
-        if not settings.REGISTRATION_OPEN:
+        if not is_registration_open():
             return HttpResponseBadRequest(
                 "You cannot change teams after registration has closed.".encode(
                     encoding="utf-8"

--- a/hackathon_site/registration/views.py
+++ b/hackathon_site/registration/views.py
@@ -11,7 +11,7 @@ from django_registration.backends.activation.views import (
     ActivationView as _ActivationView,
 )
 
-
+from hackathon_site.utils import is_registration_open
 from registration.forms import SignUpForm, ApplicationForm
 from registration.models import Team
 
@@ -23,6 +23,9 @@ class SignUpView(RegistrationView):
     email_body_template = "registration/emails/activation_email_body.html"
     success_url = reverse_lazy("registration:signup_complete")
     disallowed_url = reverse_lazy("registration:signup_closed")
+
+    def registration_allowed(self):
+        return is_registration_open()
 
     def get_email_context(self, activation_key):
         context = super().get_email_context(activation_key)


### PR DESCRIPTION
Previously, we computed a `REGISTRATION_OPEN` setting based on `datetime.now()` in the settings file. However, the settings file is only evaluated once when django in brought up - so in production, the `REGISTRATION_OPEN` setting would never change from what it was at deploy.

## Changes
- Add an `is_registration_open()` function to compute on the fly
- Replace all uses of the old `REGISTRATION_OPEN` setting with the new function
- Fix logout and login redirect urls, since I found the issue while working on this

## Steps to QA
- Set the `REGISTRATION_OPEN_DATE` to sometime a few minutes in the future.
- Start or reload the dev server. Confirm that you can't register (eg by going to /registration/signup/, noticing that the apply button is not on the landing page, etc)
- Wait for a few minutes to pass until you are beyound your chosen `REGISTRATION_OPEN_DATE`, and **do not let the django dev server reload**. You should now be able to register.
