### PR TITLE
Include Details in Activation Failed Template

### DIFF
--- a/hackathon_site/registration/jinja2/registration/activation_failed.html
+++ b/hackathon_site/registration/jinja2/registration/activation_failed.html
@@ -5,8 +5,19 @@
     <div class="section">
         <div class="loginDiv z-depth-3 row">
             <div class="row col s12 flexColCenter">
-                <h1 class="formH1">Activation failed</h1>
-                <p>We were unable to activate your account. Please <a href="mailto:{{ email }}" class="hoverLink primaryText">contact us</a> for help.</p>
+                {% if activation_error["code"] == "already_activated" %}
+                    <h1 class="formH1">Account already activated</h1>
+                    <p>You're good to go! Please <a href="{{ url("event:login") }}">log in</a> to continue.</p>
+                {% elif activation_error["code"] == "expired" %}
+                    <h1 class="formH1">Activation link has expired</h1>
+                    <p>The activation link you have used has expired. Please <a href="mailto:{{ contact_email }}" class="hoverLink primaryText">contact us</a> for help.</p>
+                {% elif activation_error["code"] == "invalid_key" or activation_error["code"] == "bad_username" %}
+                    <h1 class="formH1">Activation link is invalid</h1>
+                    <p>The activation link you have used is invalid. Please <a href="mailto:{{ contact_email }}" class="hoverLink primaryText">contact us</a> for help.</p>
+                {% else %}
+                    <h1 class="formH1">Activation failed</h1>
+                    <p>We were unable to activate your account. Please <a href="mailto:{{ contact_email }}" class="hoverLink primaryText">contact us</a> for help.</p>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/hackathon_site/registration/jinja2/registration/emails/activation_email_body.html
+++ b/hackathon_site/registration/jinja2/registration/emails/activation_email_body.html
@@ -2,7 +2,7 @@
 
 <p>Hello {{ user.first_name|striptags }},</p>
 
-<p>Thank you for registering for {{ hackathon_name }}! To get started with your application, please <a href="{{ activation_url }}">click here</a> to verify your email. After verifying, please login to continue with your application.</p>
+<p>Thank you for registering for {{ hackathon_name }}! To get started with your application, please <a href="{{ activation_url }}">click here</a> to verify your email. This link will expire in {{ expiration_days }} days. After verifying, please login to continue with your application.</p>
 
 <p>We look forward to hacking with you soon!</p>
 

--- a/hackathon_site/registration/jinja2/registration/emails/activation_email_body.txt
+++ b/hackathon_site/registration/jinja2/registration/emails/activation_email_body.txt
@@ -2,7 +2,7 @@
 
 Hello {{ user.first_name }},
 
-Thank you for registering for {{ hackathon_name }}! To get started with your application, please copy this link into your browser to verify your email: {{ activation_url }}.
+Thank you for registering for {{ hackathon_name }}! To get started with your application, please copy this link into your browser to verify your email: {{ activation_url }}. This link will expire in {{ expiration_days }} days. 
 
 After verifying, please login to continue with your application. We look forward to hacking with you soon!
 

--- a/hackathon_site/registration/views.py
+++ b/hackathon_site/registration/views.py
@@ -89,15 +89,10 @@ class SignUpView(RegistrationView):
 
 
 class ActivationView(_ActivationView):
-    success_url = reverse_lazy("event:dashboard")
+    success_url = reverse_lazy("event:login")
     # This page only gets rendered if something went wrong, otherwise
     # the user is redirected
     template_name = "registration/activation_failed.html"
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["email"] = settings.CONTACT_EMAIL
-        return context
 
 
 class ApplicationView(LoginRequiredMixin, CreateView):


### PR DESCRIPTION
Resolves #168 

## Changes
- Add more details in the account activation failed template about why activation failed
- Include activation expiration time in the email

## Steps to QA
- Sign up for an account, look for the activation email in the dev console, and try messing with it.