### PR TITLE
Show a different template for registration closed before they open

### DIFF
--- a/hackathon_site/registration/jinja2/registration/signup_closed.html
+++ b/hackathon_site/registration/jinja2/registration/signup_closed.html
@@ -5,9 +5,18 @@
     <div class="section">
         <div class="loginDiv z-depth-3 row">
             <div class="row col s12 flexColCenter">
-                <h1 class="formH1">Applications have closed</h1>
-                <p>Unfortunately, the deadline to apply for {{ hackathon_name }} was {{ localtime(registration_close_date).strftime("%B %-d, %Y") }}.</p>
-                <p>If you have any questions or concerns, please <a href="mailto:{{ email }}" class="hoverLink primaryText">contact us</a>.</p>
+                {% if localtime(now()) < registration_open_date %}
+                    <h1 class="formH1">Applications have not opened yet</h1>
+                    <p>Applications for {{ event_name }} will open on {{ localtime(registration_open_date).strftime("%B %-d, %Y") }}. Please check back then!</p>
+                {% elif registration_open_date <= localtime(now()) < registration_close_date %}
+                    <h1 class="formH1">Applications are open!</h1>
+                    <p>What brings you here? Visit the <a href="{{ url("registration:signup") }}">sign up</a> page to get started.</p>
+                {% else %}
+                    <h1 class="formH1">Applications have closed</h1>
+                    <p>Unfortunately, the deadline to apply for {{ event_name }} was {{ localtime(registration_close_date).strftime("%B %-d, %Y") }}.</p>
+                {% endif %}
+                <br />
+                <p>If you have any questions or concerns, please <a href="mailto:{{ contact_email }}" class="hoverLink primaryText">contact us</a>.</p>
             </div>
         </div>
     </div>

--- a/hackathon_site/registration/test_views.py
+++ b/hackathon_site/registration/test_views.py
@@ -74,6 +74,9 @@ class SignUpClosedViewTestCase(TestCase):
         mock_now.return_value = datetime(2020, 1, 1, tzinfo=settings.TZ_INFO)
         response = self.client.get(self.view)
         self.assertContains(response, "Applications have not opened yet")
+        self.assertContains(
+            response, settings.REGISTRATION_OPEN_DATE.strftime("%B %-d, %Y")
+        )
 
     @override_settings(
         REGISTRATION_OPEN_DATE=datetime(2020, 1, 1, tzinfo=settings.TZ_INFO)
@@ -86,6 +89,7 @@ class SignUpClosedViewTestCase(TestCase):
         mock_now.return_value = datetime(2020, 1, 2, tzinfo=settings.TZ_INFO)
         response = self.client.get(self.view)
         self.assertContains(response, "Applications are open!")
+        self.assertContains(response, reverse("registration:signup"))
 
     @override_settings(
         REGISTRATION_OPEN_DATE=datetime(2020, 1, 1, tzinfo=settings.TZ_INFO)
@@ -98,6 +102,9 @@ class SignUpClosedViewTestCase(TestCase):
         mock_now.return_value = datetime(2020, 1, 3, tzinfo=settings.TZ_INFO)
         response = self.client.get(self.view)
         self.assertContains(response, "Applications have closed")
+        self.assertContains(
+            response, settings.REGISTRATION_CLOSE_DATE.strftime("%B %-d, %Y")
+        )
 
 
 class ActivationViewTestCase(SetupUserMixin, TestCase):
@@ -218,16 +225,6 @@ class MiscRegistrationViewsTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         # Test that the default from email was passed in as a context variable
         self.assertContains(response, settings.DEFAULT_FROM_EMAIL)
-
-    def test_signup_closed(self):
-        response = self.client.get(reverse("registration:signup_closed"))
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # Test that context variables were passed in
-        self.assertContains(response, settings.HACKATHON_NAME)
-        self.assertContains(response, settings.CONTACT_EMAIL)
-        self.assertContains(
-            response, settings.REGISTRATION_CLOSE_DATE.strftime("%B %-d, %Y")
-        )
 
 
 class LeaveTeamViewTestCase(SetupUserMixin, TestCase):

--- a/hackathon_site/registration/urls.py
+++ b/hackathon_site/registration/urls.py
@@ -5,6 +5,7 @@ from registration import views
 
 app_name = "registration"
 
+
 urlpatterns = [
     path("signup/", views.SignUpView.as_view(), name="signup"),
     path(
@@ -15,18 +16,7 @@ urlpatterns = [
         ),
         name="signup_complete",
     ),
-    path(
-        "signup/closed/",
-        TemplateView.as_view(
-            template_name="registration/signup_closed.html",
-            extra_context={
-                "hackathon_name": settings.HACKATHON_NAME,
-                "email": settings.CONTACT_EMAIL,
-                "registration_close_date": settings.REGISTRATION_CLOSE_DATE,
-            },
-        ),
-        name="signup_closed",
-    ),
+    path("signup/closed/", views.SignUpClosedView.as_view(), name="signup_closed",),
     path(
         "activate/<str:activation_key>/",
         views.ActivationView.as_view(),

--- a/hackathon_site/registration/views.py
+++ b/hackathon_site/registration/views.py
@@ -1,10 +1,12 @@
+from datetime import datetime
+
 from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.urls import reverse_lazy
-from django.views.generic.base import View
+from django.views.generic.base import View, TemplateView
 from django.views.generic.edit import CreateView
 from django_registration.backends.activation.views import (
     RegistrationView,
@@ -14,6 +16,10 @@ from django_registration.backends.activation.views import (
 from hackathon_site.utils import is_registration_open
 from registration.forms import SignUpForm, ApplicationForm
 from registration.models import Team
+
+
+def _now():
+    return datetime.now().replace(tzinfo=settings.TZ_INFO)
 
 
 class SignUpView(RegistrationView):
@@ -86,6 +92,22 @@ class SignUpView(RegistrationView):
             return redirect(reverse_lazy("event:dashboard"))
 
         return super().get(request, *args, **kwargs)
+
+
+class SignUpClosedView(TemplateView):
+    template_name = "registration/signup_closed.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        context.update(
+            {
+                "registration_close_date": settings.REGISTRATION_CLOSE_DATE,
+                "registration_open_date": settings.REGISTRATION_OPEN_DATE,
+                "now": _now,
+            }
+        )
+        return context
 
 
 class ActivationView(_ActivationView):


### PR DESCRIPTION
Resolves #165 

## Changes
- Signup closed template now displays a different message if:
    - Registration not open yet
    - Registration is open (and they navigated to the page manually)
    - Registration has closed

## Steps to QA
- Change the registration dates in the main settings file so that you fall into each of the above cases, and visit /registration/signup/closed/