### PR TITLE
Redirect from application page if applications are closed

### DIFF
--- a/hackathon_site/registration/forms.py
+++ b/hackathon_site/registration/forms.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.conf import settings
 from django.contrib.auth.forms import UserCreationForm
 from django.utils.translation import gettext_lazy as _
 from django_registration import validators
@@ -131,9 +130,7 @@ class ApplicationForm(forms.ModelForm):
         self.user = kwargs.pop("user")
         super().__init__(*args, **kwargs)
         self.label_suffix = ""
-        self.fields[
-            "conduct_agree"
-        ].required = True  # TODO: these don't stay checked on page reload
+        self.fields["conduct_agree"].required = True
         self.fields["data_agree"].required = True
 
     def clean(self):

--- a/hackathon_site/registration/test_views.py
+++ b/hackathon_site/registration/test_views.py
@@ -201,15 +201,20 @@ class ApplicationViewTestCase(SetupUserMixin, TestCase):
         self.assertEqual(Application.objects.count(), 1)
         self.assertEqual(Application.objects.first().user, self.user)
 
-    def test_redirects_get_if_has_application(self):
+    def test_redirects_if_has_application(self):
         Application.objects.create(user=self.user, team=self.team, **self.data)
         self._login()
         response = self.client.get(self.view)
         self.assertRedirects(response, reverse("event:dashboard"))
+        response = self.client.post(self.view, data=self.post_data)
+        self.assertRedirects(response, reverse("event:dashboard"))
 
-    def test_redirects_post_if_has_application(self):
-        Application.objects.create(user=self.user, team=self.team, **self.data)
+    @patch("registration.views.is_registration_open")
+    def test_redirects_if_registration_closed(self, mock_is_registration_open):
+        mock_is_registration_open.return_value = False
         self._login()
+        response = self.client.get(self.view)
+        self.assertRedirects(response, reverse("event:dashboard"))
         response = self.client.post(self.view, data=self.post_data)
         self.assertRedirects(response, reverse("event:dashboard"))
 

--- a/hackathon_site/registration/views.py
+++ b/hackathon_site/registration/views.py
@@ -131,6 +131,9 @@ class ApplicationView(LoginRequiredMixin, CreateView):
         if hasattr(request.user, "application"):
             return redirect(reverse_lazy("event:dashboard"))
 
+        if not is_registration_open():
+            return redirect(reverse_lazy("event:dashboard"))
+
         return super().dispatch(request, *args, **kwargs)
 
 


### PR DESCRIPTION
Resolves #173 

## Changes
- Redirects from application page if applications are closed

## Steps to QA
- Sign in to an account without an application
- Change the registration date to something that's not now
- Go to /registration/application/. You should be redirected to the dashboard (which will say applications are closed).