### PR TITLE
Add View for Resumes

### DIFF
--- a/hackathon_site/hackathon_site/test_views.py
+++ b/hackathon_site/hackathon_site/test_views.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+from django.conf import settings
+from django.contrib.auth.models import Permission
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+
+from hackathon_site.tests import SetupUserMixin
+
+
+class ResumeViewTestCase(SetupUserMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+
+        # Create a sample file on disk
+        file = Path(settings.MEDIA_ROOT, "applications", "resumes", "my_resume.txt")
+        file.write_bytes(b"I enjoy doing things")
+
+        self.url = reverse("resume", kwargs={"filename": "my_resume.txt"})
+
+    def _login_with_permissions(self):
+        permission = Permission.objects.get(
+            content_type__app_label="registration", codename="view_application"
+        )
+        self.user.user_permissions.add(permission)
+        self._login()
+
+    def test_requires_login(self):
+        response = self.client.get(self.url)
+        self.assertRedirects(response, f"{settings.LOGIN_URL}?next={self.url}")
+
+    def test_requires_permission(self):
+        self._login()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_file_not_found(self):
+        self._login_with_permissions()
+        response = self.client.get(
+            reverse("resume", kwargs={"filename": "does-not-exist.txt"})
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_response_found(self):
+        self._login_with_permissions()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.get("Content-Type"), "text/plain")

--- a/hackathon_site/hackathon_site/test_views.py
+++ b/hackathon_site/hackathon_site/test_views.py
@@ -15,6 +15,9 @@ class ResumeViewTestCase(SetupUserMixin, TestCase):
 
         # Create a sample file on disk
         file = Path(settings.MEDIA_ROOT, "applications", "resumes", "my_resume.txt")
+        if not file.parent.exists():
+            # Make the folder on disk if necessary
+            file.parent.mkdir(parents=True)
         file.write_bytes(b"I enjoy doing things")
 
         self.url = reverse("resume", kwargs={"filename": "my_resume.txt"})

--- a/hackathon_site/hackathon_site/urls.py
+++ b/hackathon_site/hackathon_site/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include, re_path
+from django.urls import path, include
 from django.conf.urls import url
 from django.conf import settings
 
@@ -56,6 +56,7 @@ if not settings.MEDIA_URL.startswith("http"):
 if settings.DEBUG:
     import debug_toolbar
     from django.core.exceptions import ImproperlyConfigured
+    from django.urls import re_path
     from django.views.static import serve
 
     urlpatterns += [path("__debug__/", include(debug_toolbar.urls))]

--- a/hackathon_site/hackathon_site/urls.py
+++ b/hackathon_site/hackathon_site/urls.py
@@ -14,12 +14,14 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, re_path
 from django.conf.urls import url
 from django.conf import settings
 
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
+
+from registration.views import ResumeView
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -39,14 +41,21 @@ urlpatterns = [
         name="schema-swagger-ui",
     ),
     path("registration/", include("registration.urls", namespace="registration")),
-    path("", include("event.urls", namespace="event")),
 ]
+
+if not settings.MEDIA_URL.startswith("http"):
+    urlpatterns += [
+        path(
+            "%s/applications/resumes/<str:filename>" % settings.MEDIA_URL.strip("/"),
+            ResumeView.as_view(),
+            name="resume",
+        ),
+    ]
 
 
 if settings.DEBUG:
     import debug_toolbar
     from django.core.exceptions import ImproperlyConfigured
-    from django.urls import re_path
     from django.views.static import serve
 
     urlpatterns += [path("__debug__/", include(debug_toolbar.urls))]
@@ -63,3 +72,6 @@ if settings.DEBUG:
             {"document_root": settings.MEDIA_ROOT},
         )
     ]
+
+# Catchall for event urls at the end of the url routes
+urlpatterns += [path("", include("event.urls", namespace="event"))]


### PR DESCRIPTION
Resolves #177 

## Changes
- Adds a view for resumes, which requires login and `view_application` permissions.

## Steps to QA
- Fill out the application form and submit a resume
- Find the application in the admin site. Click the link to the file, and it should show up.