### PR TITLE
Revert "179 admin site plus"

### DIFF
--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -53,14 +53,13 @@ CORS_ALLOW_CREDENTIALS = True
 # Application definition
 
 INSTALLED_APPS = [
-    "django.contrib.admin.apps.SimpleAdminConfig",
+    "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.forms",
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "adminplus",
     "corsheaders",
     "rest_framework",
     "rest_framework.authtoken",

--- a/hackathon_site/hackathon_site/urls.py
+++ b/hackathon_site/hackathon_site/urls.py
@@ -14,7 +14,6 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from adminplus.sites import AdminSitePlus
 from django.urls import path, include
 from django.conf.urls import url
 from django.conf import settings
@@ -23,9 +22,6 @@ from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 
 from registration.views import ResumeView
-
-admin.site = AdminSitePlus()
-admin.autodiscover()
 
 schema_view = get_schema_view(
     openapi.Info(

--- a/hackathon_site/requirements.txt
+++ b/hackathon_site/requirements.txt
@@ -9,7 +9,6 @@ coreapi==2.3.3
 coreschema==0.0.4
 dj-rest-auth==1.0.6
 Django==3.1.1
-django-adminplus==0.5
 django-cors-headers==3.3.0
 django-debug-toolbar==2.2
 django-registration==3.1


### PR DESCRIPTION
Reverts ieeeuoft/hackathon-template#196

Unfortunately, we missed that this messes with autodetection. It looks like things registered with the `@admin.register` decorator don't appear, which includes the built in Django auth models. We're looking into other ways to add custom views for the review part of the admin site, such as https://docs.djangoproject.com/en/3.1/ref/contrib/admin/#adding-views-to-admin-sites