### PR TITLE
Add Redis cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,17 @@ $ pip install -r requirements.txt
 ### Environment Variables
 In order to run the django and react development servers locally (or run tests), the following environment variables are used. Those in **bold** are required.
 
-| **Variable**   | **Required value**                | **Default**    | **Description**                                                                   |
-|----------------|-----------------------------------|----------------|-----------------------------------------------------------------------------------|
-| **DEBUG**      | 1                                 | 0              | Run Django in debug mode. Required to run locally.                                |
-| **SECRET_KEY** | Something secret, create your own | None           | Secret key for cryptographic signing. Must not be shared. Required.               |
-| DB_HOST        |                                   | 127.0.0.1      | Postgres database host.                                                           |
-| DB_USER        |                                   | postgres       | User on the postgres database. Must have permissions to create and modify tables. |
-| DB_PASSWORD    |                                   |                | Password for the postgres user.                                                   |
-| DB_PORT        |                                   | 5432           | Port the postgres server is open on.                                              |
-| DB_NAME        |                                   | hackathon_site | Postgres database name.                                                           |
-| **REACT_APP_DEV_SERVER_URL** | http://localhost:8000 |              | Path to the django development server, used by React. Update the port if you aren't using the default 8000. |
+| **Variable**   | **Required value**                | **Default**       | **Description**                                                                   |
+|----------------|-----------------------------------|-------------------|-----------------------------------------------------------------------------------|
+| **DEBUG**      | 1                                 | 0                 | Run Django in debug mode. Required to run locally.                                |
+| **SECRET_KEY** | Something secret, create your own | None              | Secret key for cryptographic signing. Must not be shared. Required.               |
+| DB_HOST        |                                   | 127.0.0.1         | Postgres database host.                                                           |
+| DB_USER        |                                   | postgres          | User on the postgres database. Must have permissions to create and modify tables. |
+| DB_PASSWORD    |                                   |                   | Password for the postgres user.                                                   |
+| DB_PORT        |                                   | 5432              | Port the postgres server is open on.                                              |
+| DB_NAME        |                                   | hackathon_site    | Postgres database name.                                                           |
+| REDIS_URI      |                                   | 172.17.0.1:6379/1 | Redis [URI](https://github.com/lettuce-io/lettuce-core/wiki/Redis-URI-and-connection-details#uri-syntax). `<host>:<port>/<database>`. |
+| **REACT_APP_DEV_SERVER_URL** | http://localhost:8000 |                 | Path to the django development server, used by React. Update the port if you aren't using the default 8000. |
 
 #### Testing
 Specifying `SECRET_KEY` is still required to run tests, because the settings file expects it to be set. `DEBUG` is forced to `False` by Django.
@@ -85,6 +86,11 @@ To shut down the database and all other services:
 $ docker-compose -f development/docker-compose.yml down
 ```
 
+To run only the database service:
+```bash
+$ docker-compose -f development/docker-compose.yml up -d postgres
+```
+
 The postgres container uses a volume mounted to `development/.postgres-data/` for persistent data storage, so you can safely stop the service without losing any data in your local database.
 
 A note about security: by default, the Postgres service is run with [trust authentication](https://www.postgresql.org/docs/current/auth-trust.html) for convenience, so no passwords are required even if they are set. You should not store any sensitive information in your local database, or broadcast your database host publicly with these settings.
@@ -95,6 +101,21 @@ A note about security: by default, the Postgres service is run with [trust authe
 $ cd hackathon_site
 $ python manage.py migrate
 ```
+
+#### Cache
+This application also relies on a cache, for which we use [Redis](https://redis.io/).
+
+You may install Redis on your machine if you wish, but we recommend running it locally using docker. A Redis service is available in [development/docker-compose.yml](/home/graham/ieee/hackathon-template/README.md). To run all the services, including the database:
+```bash
+$ docker-compose -f development/docker-compose.yml up -d
+```
+
+To run only the redis service:
+```bash
+$ docker-compose -f development/docker-compose.yml up -d redis
+```
+
+If you run multiple instances of this application in production using Redis through Docker (perhaps in Swarm mode), you should make sure that the Redis databases used between applications do not conflict. The easiest way to do this is to change the database id in the [Redis URI environment variable](#environment-variables), eg to `172.17.0.1:6379/2`.
 
 #### Run the development server
 Finally, you can run the development server, by default on port 8000. From above, you should already be in the top-level `hackathon_site` directory:

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Profiles are used by participants who have either been accepted or waitlisted. S
 #### Django
 Django tests are run using [Django's test system](https://docs.djangoproject.com/en/3.0/topics/testing/overview/), based on the standard python `unittest` module.
 
-A custom settings settings module is available for testing, which tells Django to use an in-memory sqlite3 database instead of the postgresql database for testing. To run the full test suite locally:
+A custom settings settings module is available for testing, which tells Django to use an in-memory sqlite3 database instead of the postgresql database and to use an in-memory cache instead of Redis. To run the full test suite locally:
 
 ```bash
 $ cd hackathon_site

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -10,3 +10,7 @@ services:
             - POSTGRES_HOST_AUTH_METHOD=trust
         volumes:
             - ./.postgres-data:/var/lib/postgresql/data
+    redis:
+        image: redis:6-alpine
+        ports:
+            - 6379:6379

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -134,6 +134,16 @@ DATABASES = {
     }
 }
 
+# Cache
+# https://docs.djangoproject.com/en/3.1/topics/cache/
+REDIS_URI = os.environ.get("REDIS_URI", "172.17.0.1:6379/1")
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": f"redis://{REDIS_URI}",
+        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient",},
+    }
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -142,6 +142,8 @@ CACHES = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": f"redis://{REDIS_URI}",
         "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient",},
+        # Default time for cache key expiry, in seconds. Can be changed on a per-key basis
+        "TIMEOUT": 600,
     }
 }
 

--- a/hackathon_site/hackathon_site/settings/ci.py
+++ b/hackathon_site/hackathon_site/settings/ci.py
@@ -25,6 +25,13 @@ IN_TESTING = True
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "test-cache",
+    }
+}
+
 # For testing, make the media root a local folder to avoid
 # permissions errors
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")

--- a/hackathon_site/requirements.txt
+++ b/hackathon_site/requirements.txt
@@ -11,6 +11,7 @@ dj-rest-auth==1.0.6
 Django==3.1.1
 django-cors-headers==3.3.0
 django-debug-toolbar==2.2
+django-redis==4.12.1
 django-registration==3.1
 djangorestframework==3.11.0
 drf-yasg==1.17.1
@@ -28,6 +29,7 @@ psycopg2-binary==2.8.5
 pyparsing==2.4.7
 pytz==2020.1
 PyYAML==5.3.1
+redis==3.5.3
 regex==2020.4.4
 requests==2.24.0
 ruamel.yaml==0.16.10


### PR DESCRIPTION
## Overview

- Resolves #202 
- Adds [django-redis](https://github.com/jazzband/django-redis) as a cache backend
- Adds a redis service to the development docker compose configuration


## Unit Tests Created
- None, but set up the test settings file to use a local memory cache instead of redis

## Steps to QA
- Install requirements again, and re-up the docker compose stack to get the redis service.
- In a `python manage.py shell`:

```python
In [1]: from django.core.cache import cache                                                                                                                                                                                                                                              

In [2]: key = "foobar"                                                                                                                                                                                                                                                                   

In [3]: cache.set(key, "hello there")                                                                                                                                                                                                                                                    
Out[3]: True

In [4]: cache.get(key)                                                                                                                                                                                                                                                                   
Out[4]: 'hello there'

In [5]: cache.delete(key)                                                                                                                                                                                                                                                                
Out[5]: 1

In [6]: cache.get(key) 
```

