### PR TITLE
Reviewer Assignment

### DIFF
--- a/hackathon_site/hackathon_site/tests.py
+++ b/hackathon_site/hackathon_site/tests.py
@@ -51,7 +51,7 @@ class SetupUserMixin:
         return self._apply_as_user(self.user)
 
     @staticmethod
-    def __get_random_email():
+    def _get_random_email():
         """
         Return a random email not associated with any user
         """
@@ -80,16 +80,16 @@ class SetupUserMixin:
         else:
             # Make some random users
             user1 = User.objects.create_user(
-                username=self.__get_random_email(), password="foobar123"
+                username=self._get_random_email(), password="foobar123"
             )
             user2 = User.objects.create_user(
-                username=self.__get_random_email(), password="foobar123"
+                username=self._get_random_email(), password="foobar123"
             )
             user3 = User.objects.create_user(
-                username=self.__get_random_email(), password="foobar123"
+                username=self._get_random_email(), password="foobar123"
             )
             user4 = User.objects.create_user(
-                username=self.__get_random_email(), password="foobar123"
+                username=self._get_random_email(), password="foobar123"
             )
 
         self._apply_as_user(user1, team)

--- a/hackathon_site/hackathon_site/tests.py
+++ b/hackathon_site/hackathon_site/tests.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
 from unittest.mock import patch
+from uuid import uuid4
 
 from django.conf import settings
 from django.test import TestCase, override_settings
@@ -49,24 +50,52 @@ class SetupUserMixin:
     def _apply(self):
         return self._apply_as_user(self.user)
 
-    def _make_full_registration_team(self, team=None):
+    @staticmethod
+    def __get_random_email():
+        """
+        Return a random email not associated with any user
+        """
+        uuid = uuid4().hex
+        email = f"{uuid[:10]}@{uuid[10:20]}.com"
+        while User.objects.filter(username=email).exists():
+            uuid = uuid4().hex
+            email = f"{uuid[:10]}@{uuid[10:20]}.com"
+        return email
+
+    def _make_full_registration_team(self, team=None, self_users=True):
         if team is None:
             team = RegistrationTeam.objects.create()
 
-        self.user2 = User.objects.create_user(
-            username="frank@johnston.com", password="hellothere31415"
-        )
-        self.user3 = User.objects.create_user(
-            username="franklin@carmichael", password="supersecret456"
-        )
-        self.user4 = User.objects.create_user(
-            username="lawren@harris", password="wxyz7890"
-        )
+        if self_users:
+            user1 = self.user
+            user2 = self.user2 = User.objects.create_user(
+                username="frank@johnston.com", password="hellothere31415"
+            )
+            user3 = self.user3 = User.objects.create_user(
+                username="franklin@carmichael.com", password="supersecret456"
+            )
+            user4 = self.user4 = User.objects.create_user(
+                username="lawren@harris.com", password="wxyz7890"
+            )
+        else:
+            # Make some random users
+            user1 = User.objects.create_user(
+                username=self.__get_random_email(), password="foobar123"
+            )
+            user2 = User.objects.create_user(
+                username=self.__get_random_email(), password="foobar123"
+            )
+            user3 = User.objects.create_user(
+                username=self.__get_random_email(), password="foobar123"
+            )
+            user4 = User.objects.create_user(
+                username=self.__get_random_email(), password="foobar123"
+            )
 
-        self._apply_as_user(self.user, team)
-        self._apply_as_user(self.user2, team)
-        self._apply_as_user(self.user3, team)
-        self._apply_as_user(self.user4, team)
+        self._apply_as_user(user1, team)
+        self._apply_as_user(user2, team)
+        self._apply_as_user(user3, team)
+        self._apply_as_user(user4, team)
 
         return team
 

--- a/hackathon_site/review/admin.py
+++ b/hackathon_site/review/admin.py
@@ -262,10 +262,8 @@ class TeamReviewAdmin(admin.ModelAdmin):
         first.
 
         Each user can be assigned as a reviewer to one team. When that user
-        requests a new team, they are unassigned from the previous one.
-
-        If a user requests a team but never completes that application and never
-        requests a new team, that team will remain in the cache set of assigned teams.
+        requests a new team, they are unassigned from the previous one. The assignment
+        will expire after 20 minutes.
         """
 
         if not self.has_change_permission(request):

--- a/hackathon_site/review/admin.py
+++ b/hackathon_site/review/admin.py
@@ -18,6 +18,7 @@ from review.models import Review, TeamReview
 class ReviewAdmin(admin.ModelAdmin):
     list_display = ("get_user", "status", "decision_sent_date", "get_reviewer")
     list_filter = (
+        "status",
         ("decision_sent_date", admin.EmptyFieldListFilter),
         ("reviewer", admin.RelatedOnlyFieldListFilter),
     )

--- a/hackathon_site/review/admin.py
+++ b/hackathon_site/review/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin, messages
 from django.core.cache import cache
+from django.core.exceptions import PermissionDenied
 from django.db.models import Count, Max
 from django.db import transaction
 from django.urls import reverse, path
@@ -257,8 +258,10 @@ class TeamReviewAdmin(admin.ModelAdmin):
 
         If a user requests a team but never completes that application and never
         requests a new team, that team will remain in the cache set of assigned teams.
-
         """
+
+        if not self.has_change_permission(request):
+            raise PermissionDenied
 
         active_reviewers_set_cache_key = "admin:assign_to_team:active_reviewers"
 

--- a/hackathon_site/review/admin.py
+++ b/hackathon_site/review/admin.py
@@ -181,6 +181,11 @@ class TeamReviewAdmin(admin.ModelAdmin):
     change_list_template = "review/change_list.html"
     readonly_fields = ("team_code",)
 
+    def changelist_view(self, request, extra_context=None):
+        extra_context = extra_context or {}
+        extra_context["has_change_permission"] = self.has_change_permission(request)
+        return super().changelist_view(request, extra_context)
+
     def get_queryset(self, request):
         return (
             super()

--- a/hackathon_site/review/admin.py
+++ b/hackathon_site/review/admin.py
@@ -43,6 +43,13 @@ class ReviewAdmin(admin.ModelAdmin):
     get_reviewer.short_description = "Reviewer"
     get_reviewer.admin_order_field = "reviewer__first_name"
 
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("application", "application__user", "reviewer")
+        )
+
 
 class ApplicationInline(admin.TabularInline):
     model = Application

--- a/hackathon_site/review/admin.py
+++ b/hackathon_site/review/admin.py
@@ -1,9 +1,12 @@
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.core.cache import cache
 from django.db.models import Count, Max
+from django.db import transaction
+from django.urls import reverse, path
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
-from django.http import HttpResponse
+from django.http import HttpResponseRedirect
 
 from registration.models import Application
 from review.forms import ReviewForm, ApplicationReviewInlineFormset
@@ -239,14 +242,90 @@ class TeamReviewAdmin(admin.ModelAdmin):
 
     def assign_to_team_view(self, request):
         """
-        Temporary placeholder view to demonstrate the use of extra URLs and
-        template overriding. Should be replaced with the view to assign to teams.
+        Assign the current user to the next team with no reviewer assigned.
+        Teams are ordered by the most recently submitted application on that team
+        ascending, so teams with all applications submitted earlier get reviewed
+        first.
+
+        Each user can be assigned as a reviewer to one team. When that user
+        requests a new team, they are unassigned from the previous one.
+
+        If a user requests a team but never completes that application and never
+        requests a new team, that team will remain in the cache set of assigned teams.
+
         """
-        return HttpResponse(f"Hello there, {request.user.first_name}")
+
+        active_reviewers_set_cache_key = "admin:assign_to_team:active_reviewers"
+
+        def build_reviewer_assignment_cache_key(user_id):
+            """
+            Build a key that stores which team a reviewer is assigned to
+            """
+            return f"admin:assign_to_team:user-{user_id}"
+
+        with transaction.atomic():
+            # Set of reviewers IDs that are currently reviewing
+            active_reviewers = cache.get(active_reviewers_set_cache_key, set())
+
+            # Get a dictionary mapping user id -> assigned team
+            assigned_teams = cache.get_many(
+                [
+                    build_reviewer_assignment_cache_key(user_id)
+                    for user_id in active_reviewers
+                ]
+            )
+
+            current_user_cache_key = build_reviewer_assignment_cache_key(
+                request.user.id
+            )
+
+            queryset = (
+                self.get_queryset(request)
+                .filter(applications__isnull=False)  # Exclude any teams that are empty
+                # Get any team where at least one application is missing a review
+                .filter(applications__review__isnull=True)
+                .exclude(
+                    id__in=list(assigned_teams.values())
+                )  # Exclude teams that are currently assigned
+                .order_by(
+                    "most_recent_submission"
+                )  # Ascending order, annotated in self.get_queryset
+            )
+
+            team = queryset.first()
+
+            if team is None:
+                # No more teams left to review
+                cache.delete(current_user_cache_key)
+
+                messages.add_message(
+                    request,
+                    messages.INFO,
+                    "No more teams remaining. Note that some reviews may still be in progress, "
+                    "so check back later to ensure all were completed",
+                )
+
+                return HttpResponseRedirect(
+                    reverse("admin:review_teamreview_changelist")
+                )
+
+            # Assign the user to their team in the cache, 20 minute TTL
+            cache.set(current_user_cache_key, team.id, timeout=60 * 20)
+
+            # Add the user to the set of active reviewers
+            active_reviewers.add(request.user.id)
+
+            # Update the active reviewers cache set, 20 minute TTL
+            cache.set(
+                active_reviewers_set_cache_key, active_reviewers, timeout=60 * 20,
+            )
+
+        team_review_page = reverse(
+            "admin:review_teamreview_change", kwargs={"object_id": team.id}
+        )
+        return HttpResponseRedirect(team_review_page)
 
     def get_urls(self):
-        from django.urls import path
-
         urls = super().get_urls()
         new_urls = [
             path(

--- a/hackathon_site/review/templates/review/change_list.html
+++ b/hackathon_site/review/templates/review/change_list.html
@@ -8,7 +8,7 @@
 &rsaquo; <a href="{% url 'admin:app_list' app_label=cl.opts.app_label %}">{{ cl.opts.app_config.verbose_name }}</a>
 &rsaquo; {{ cl.opts.verbose_name_plural|capfirst }}
     {% if has_change_permission %}
-    <a class="button" style="float: right; margin: -4px 15px -4px -5px;" href="{% url 'admin:assign-reviewer-to-team' %}">Review next team</a>
+    <a class="button" style="float: right; margin: -4px 15px -4px -5px;" href="{% url 'admin:assign-reviewer-to-team' %}">Review Next Team</a>
     {% endif %}
 </div>
 {% endblock %}

--- a/hackathon_site/review/templates/review/change_list.html
+++ b/hackathon_site/review/templates/review/change_list.html
@@ -7,6 +7,8 @@
 <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
 &rsaquo; <a href="{% url 'admin:app_list' app_label=cl.opts.app_label %}">{{ cl.opts.app_config.verbose_name }}</a>
 &rsaquo; {{ cl.opts.verbose_name_plural|capfirst }}
+    {% if has_change_permission %}
     <a class="button" style="float: right; margin: -4px 15px -4px -5px;" href="{% url 'admin:assign-reviewer-to-team' %}">Review next team</a>
+    {% endif %}
 </div>
 {% endblock %}

--- a/hackathon_site/review/test_admin.py
+++ b/hackathon_site/review/test_admin.py
@@ -416,7 +416,7 @@ class AssignReviewerToTeamViewTestCase(SetupUserMixin, TestCase):
 
         # Login as self.user
         self._login()
-        _ = self.client.get(self.view)
+        self.client.get(self.view)
 
         # team2 should now be assigned to self.user
         # if we get again as a different user, we should be given team3
@@ -461,7 +461,7 @@ class AssignReviewerToTeamViewTestCase(SetupUserMixin, TestCase):
 
         self._login()
         # Will assign self.user to team3
-        _ = self.client.get(self.view)
+        self.client.get(self.view)
 
         # Login as a different user. Should be taken back to the changelist page
         self.client.login(username=self.user2.username, password=self.user2_password)

--- a/hackathon_site/review/test_admin.py
+++ b/hackathon_site/review/test_admin.py
@@ -181,6 +181,24 @@ class TeamReviewListAdminTestCase(SetupUserMixin, TestCase):
         self.assertContains(response, team_2.team_code)
         self.assertNotContains(response, team_1.team_code)
 
+    def test_has_link_to_get_next_team_with_change_perms(self):
+        """
+        Test that the link to the assignment page is in the template
+        when the user has change permissions
+        """
+        self._login(self.change_permissions)
+        response = self.client.get(self.list_view)
+        self.assertContains(response, reverse("admin:assign-reviewer-to-team"))
+
+    def test_does_not_have_link_to_get_next_team_with_view_perms(self):
+        """
+        Test that the link to the assignment page is not rendered
+        when the user has only view permissions
+        """
+        self._login(self.view_permissions)
+        response = self.client.get(self.list_view)
+        self.assertNotContains(response, reverse("admin:assign-reviewer-to-team"))
+
 
 class TeamReviewChangeAdminTestCase(SetupUserMixin, TestCase):
     """


### PR DESCRIPTION
## Overview

- Resolves #198 
- Adds a view to assign a reviewer to the next team available for review, accessible from the admin site
- Made the queryset for the review changelist page more efficient, and added a filter by status

## Unit Tests Created
- Requires appropirate permissions to access the view
- Assigns the reviewer to the team with the least most recently submitted application
- Skips teams that already have reviewers assigned and assigns the next available team
- Displays messages when there aren't any teams left to review for both of the above cases

## Steps to QA
- Create a few teams, with varying application submission times
- Add a few manual reviews via the review (not team review) admin page, so that some applications are still unreviewed
- Click the "Review next team" button on the admin page. You should be assigned the next team in line to be reviewed (team with the earliest latest submitted application, check the code if that doesn't make sense).
- Create another review user that can use the admin site and submit reviews, while your main user is assigned to a team. They should get the next team in line.
- Once all teams have been reviewed or have a team member assigned, you should be redirected back to the changelist page with a message indicating that all reviews are complete.
- Leave one review unfinished, but claimed by a user. Wait at least 20 minutes for the cache to expire (or change the timeout in the code to something quicker). Should be re-claimable again.

