### PR TITLE
Send Decision Emails to Participants

### DIFF
--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -213,15 +213,38 @@ else:
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "handlers": {"console": {"level": "INFO", "class": "logging.StreamHandler"}},
+    "filters": {
+        "require_debug_false": {"()": "django.utils.log.RequireDebugFalse",},
+        "require_debug_true": {"()": "django.utils.log.RequireDebugTrue",},
+    },
+    "handlers": {
+        "console": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "filters": ["require_debug_true"],
+        },
+        "console_errors": {
+            "level": "ERROR",
+            "class": "logging.StreamHandler",
+            "filters": ["require_debug_false"],
+        },
+        "mail_admins": {
+            "level": "ERROR",
+            "filters": ["require_debug_false"],
+            "class": "django.utils.log.AdminEmailHandler",
+        },
+    },
     "loggers": {
-        "django": {"handlers": ["console"], "level": "WARNING", "propagate": True},
+        "django": {
+            "handlers": ["console", "console_errors", "mail_admins"],
+            "level": "INFO",
+            "propagate": True,
+        },
         "django.request": {
-            "handlers": ["console"],
-            "level": "WARNING",
+            "handlers": ["console", "console_errors"],
             "propagate": False,
         },
-        "review": {"handlers": ["console"], "level": "WARNING", "propagate": False},
+        "review": {"handlers": ["console", "console_errors"], "propagate": False},
     },
 }
 

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -209,6 +209,22 @@ else:
     # Remember to create this folder on your server
     MEDIA_ROOT = "/var/www/media/"
 
+# Logging
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {"console": {"level": "INFO", "class": "logging.StreamHandler"}},
+    "loggers": {
+        "django": {"handlers": ["console"], "level": "WARNING", "propagate": True},
+        "django.request": {
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+        "review": {"handlers": ["console"], "level": "WARNING", "propagate": False},
+    },
+}
+
 # Event specific settings
 HACKATHON_NAME = "CoolHacks"
 DEFAULT_FROM_EMAIL = "webmaster@localhost"

--- a/hackathon_site/review/admin.py
+++ b/hackathon_site/review/admin.py
@@ -12,6 +12,7 @@ from django.http import HttpResponseRedirect
 from registration.models import Application
 from review.forms import ReviewForm, ApplicationReviewInlineFormset
 from review.models import Review, TeamReview
+from review.views import MailerView
 
 
 @admin.register(Review)
@@ -346,6 +347,11 @@ class TeamReviewAdmin(admin.ModelAdmin):
                 "assign/",
                 self.admin_site.admin_view(self.assign_to_team_view, cacheable=True),
                 name="assign-reviewer-to-team",
-            )
+            ),
+            path(
+                "send-mail/",
+                self.admin_site.admin_view(MailerView.as_view(), cacheable=False),
+                name="send-decision-emails",
+            ),
         ]
         return new_urls + urls

--- a/hackathon_site/review/jinja2/review/emails/accepted_email_body.html
+++ b/hackathon_site/review/jinja2/review/emails/accepted_email_body.html
@@ -2,7 +2,7 @@
 
 <p>Hello {{ user.first_name|striptags }},</p>
 
-<p>The {{ hackathon_name }} team has reviewed your application, and we’re excited to welcome you to {{ hackathon_name }}! 
+<p>The {{ hackathon_name }} team has reviewed your application, and we’re excited to welcome you to {{ hackathon_name }}!
 To confirm your attendance, visit your <a href="{{ dashboard_url }}">dashboard</a> to RSVP by {{ rsvp_deadline }} otherwise your spot will be given to other applicants. Alternatively, you can press the "Cannot attend" button.</p>
 
 <p>Read our <a href="{{ participant_package_link }}">participant package</a> for all the info regarding the event, and join our <a href="{{ chat_room_link }}">Slack</a>. Stay tuned for more updates regarding detailed event logistics, and we hope to see you soon! If you have questions, read the FAQ on your <a href="{{ dashboard_url }}">dashboard</a> or feel free to contact us. </p>

--- a/hackathon_site/review/jinja2/review/emails/waitlisted_email_body.html
+++ b/hackathon_site/review/jinja2/review/emails/waitlisted_email_body.html
@@ -2,7 +2,7 @@
 
 <p>Hello {{ user.first_name|striptags }},</p>
 
-<p>The {{ hackathon_name }} team has reviewed your application, and due to both the high caliber and high volume of applications, we have decided to defer your application to the next round. You will hear back from us by {{ final_review_response_date }} regarding a final application decision.</p>
+<p>The {{ hackathon_name }} team has reviewed your application, and due to both the high caliber and high volume of applications, we have decided to defer your application to the next round. You will hear back from us by {{ final_review_response_date.strftime("%B %-d, %Y") }} regarding a final application decision.</p>
 
 <p>By visiting your <a href="{{ dashboard_url }}">dashboard</a>, you can join or make changes to your team, and we’ll re-consider your application along with your teammates (though due to limited spots remaining, note that we may not make the same decision on all teammates). </p>
 

--- a/hackathon_site/review/jinja2/review/send-decisions.html
+++ b/hackathon_site/review/jinja2/review/send-decisions.html
@@ -2,7 +2,6 @@
 
 {% block head_extends %}
 <!-- Select2 CSS -->
-<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/css/select2.min.css" rel="stylesheet" />
 <link rel="stylesheet" type="text/css" href="{{ static('event/styles/css/select2.css') }}" />
 
 <style>
@@ -35,17 +34,7 @@
 
 {% block form_inputs %}
     {% for field in form %}
-        {% if field.field.widget.__class__.__name__ == "Textarea" %}
-            {{ render_field(field, size="s12", show_help_text_as_label=True) }}
-        {% elif field.field.widget.input_type == "select" %}
-            {{ render_field(field, size="s12 select2-wrapper") }}
-        {% elif field.field.widget.input_type == "file" %}
-            {{ render_field(field, size="s12", show_label=False) }}
-        {% elif field.field.widget.input_type == "checkbox" %}
-            {{ render_checkbox_field(field, size="s12") }}
-        {% else %}
-            {{ render_field(field, size="s12") }}
-        {% endif %}
+        {{ render_field(field, size="s12") }}
     {% endfor %}
 {% endblock %}
 

--- a/hackathon_site/review/jinja2/review/send-decisions.html
+++ b/hackathon_site/review/jinja2/review/send-decisions.html
@@ -1,15 +1,5 @@
 {% extends "event/form_base.html" %}
 
-{% block head_extends %}
-<!-- Select2 CSS -->
-<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/css/select2.min.css" rel="stylesheet" />
-<link rel="stylesheet" type="text/css" href="{{ static('event/styles/css/select2.css') }}" />
-
-<style>
-
-</style>
-{% endblock %}
-
 {% block form_title %}SEND DECISION EMAILS TO PARTICIPANTS{% endblock %}
 {% block form_attrs %}enctype="multipart/form-data"{% endblock %}
 
@@ -35,14 +25,16 @@
 
 {% block form_inputs %}
     {% for field in form %}
-        {% if field.field.widget.__class__.__name__ == "Textarea" %}
-            {{ render_field(field, size="s12", show_help_text_as_label=True) }}
-        {% elif field.field.widget.input_type == "select" %}
-            {{ render_field(field, size="s12 select2-wrapper") }}
-        {% elif field.field.widget.input_type == "file" %}
-            {{ render_field(field, size="s12", show_label=False) }}
-        {% elif field.field.widget.input_type == "checkbox" %}
-            {{ render_checkbox_field(field, size="s12") }}
+        {% if field.field.widget.input_type == "select" %}
+            <div class="input-field row col s12">
+                <select>
+                    <option value="" disabled selected>Choose your option</option>
+                    <option value="Accepted">Accepted</option>
+                    <option value="Waitlisted">Waitlisted</option>
+                    <option value="Rejected">Rejected</option>
+                </select>
+                <label>{{field.label}}</label>
+            </div>
         {% else %}
             {{ render_field(field, size="s12") }}
         {% endif %}
@@ -56,45 +48,9 @@
 {% endblock %}
 
 {% block scripts %}
-
-<!-- Select2 JS -->
-<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/js/select2.min.js"></script>
-
 <script>
-$(document).ready(function() {
-    const selects = $("select");
-    selects.not(".select2-school-select").select2();
-    $(".select2-school-select").select2({tags: true});  // Allow custom options for school
-
-    // Properly style any pre-filled selects
-    $.each(selects, (i, e) => {
-        if (e.value) {
-            $(e).siblings("label").addClass("label-active");
-        }
+    $(document).ready(function(){
+        $('select').formSelect();
     });
-
-    selects.on("select2:opening", function () {
-        $(this).siblings("label").addClass("label-active");
-    });
-
-    selects.on("select2:closing", function (e) {
-        if (!this.value) {
-            $(this).siblings("label").removeClass("label-active");
-        }
-
-        // steal focus during close - only capture once and stop propogation
-        // https://stackoverflow.com/a/49261426/3882202
-        $(e.target).data("select2").$selection.one("focus focusin", function (e) {
-            e.stopPropagation();
-        });
-    });
-
-    // on first focus (bubbles up to document), open the menu
-    // https://stackoverflow.com/a/49261426/3882202
-    $(document).on('focus', '.select2-selection.select2-selection--single', function () {
-      $(this).closest(".select2-container").siblings('select:enabled').select2('open');
-    });
-});
-
 </script>
 {% endblock %}

--- a/hackathon_site/review/jinja2/review/send-decisions.html
+++ b/hackathon_site/review/jinja2/review/send-decisions.html
@@ -3,9 +3,6 @@
 {% block form_title %}SEND DECISION EMAILS TO PARTICIPANTS{% endblock %}
 {% block form_attrs %}enctype="multipart/form-data"{% endblock %}
 
-
-
-
 {% set form_action=url("admin:send-decision-emails") %}
 
 {% block form_description %}
@@ -27,7 +24,7 @@
     {% for field in form %}
         {% if field.field.widget.input_type == "select" %}
             <div class="input-field row col s12">
-                <select>
+                <select id="status" name="status">
                     <option value="" disabled selected>Choose your option</option>
                     <option value="Accepted">Accepted</option>
                     <option value="Waitlisted">Waitlisted</option>

--- a/hackathon_site/review/jinja2/review/send-decisions.html
+++ b/hackathon_site/review/jinja2/review/send-decisions.html
@@ -6,16 +6,18 @@
 {% set form_action=url("admin:send-decision-emails") %}
 
 {% block form_description %}
-    <div class="row col s12">
-    {% for error in form.non_field_errors() %}
-        <span class="formError">{{ error }}</span>
-    {% endfor %}
-    </div>
+    {% if form.non_field_errors() %}
         <div class="row col s12">
-            Accepted: {{ accepted_count }}
-            Waitlisted: {{ waitlisted_count }}
-            Rejected: {{ rejected_count }}
+        {% for error in form.non_field_errors() %}
+            <span class="formError">{{ error }}</span>
+        {% endfor %}
         </div>
+    {% endif %}
+    <div class="row col s12">
+        Accepted: {{ accepted_count }}
+        Waitlisted: {{ waitlisted_count }}
+        Rejected: {{ rejected_count }}
+    </div>
 {% endblock %}
 
 {% block form_inputs %}

--- a/hackathon_site/review/jinja2/review/send-decisions.html
+++ b/hackathon_site/review/jinja2/review/send-decisions.html
@@ -1,0 +1,100 @@
+{% extends "event/form_base.html" %}
+
+{% block head_extends %}
+<!-- Select2 CSS -->
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/css/select2.min.css" rel="stylesheet" />
+<link rel="stylesheet" type="text/css" href="{{ static('event/styles/css/select2.css') }}" />
+
+<style>
+
+</style>
+{% endblock %}
+
+{% block form_title %}SEND DECISION EMAILS TO PARTICIPANTS{% endblock %}
+{% block form_attrs %}enctype="multipart/form-data"{% endblock %}
+
+
+
+
+{% set form_action=url("admin:send-decision-emails") %}
+
+{% block form_description %}
+    {% if form.non_field_errors %}
+        <div class="row col s12">
+        {% for error in form.non_field_errors() %}
+            <span class="formError">{{ error }}</span>
+        {% endfor %}
+        </div>
+        <div class="row col s12">
+            Accepted: {{ accepted_count }}
+            Waitlisted: {{ waitlisted_count }}
+            Rejected: {{ rejected_count }}
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% block form_inputs %}
+    {% for field in form %}
+        {% if field.field.widget.__class__.__name__ == "Textarea" %}
+            {{ render_field(field, size="s12", show_help_text_as_label=True) }}
+        {% elif field.field.widget.input_type == "select" %}
+            {{ render_field(field, size="s12 select2-wrapper") }}
+        {% elif field.field.widget.input_type == "file" %}
+            {{ render_field(field, size="s12", show_label=False) }}
+        {% elif field.field.widget.input_type == "checkbox" %}
+            {{ render_checkbox_field(field, size="s12") }}
+        {% else %}
+            {{ render_field(field, size="s12") }}
+        {% endif %}
+    {% endfor %}
+{% endblock %}
+
+{% block form_button %}
+<div class="input-field col s12 center" style="margin-bottom: 0">
+    <button type="submit" class="btn-small waves-effect waves-light colorBtn">Submit</button>
+</div>
+{% endblock %}
+
+{% block scripts %}
+
+<!-- Select2 JS -->
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/js/select2.min.js"></script>
+
+<script>
+$(document).ready(function() {
+    const selects = $("select");
+    selects.not(".select2-school-select").select2();
+    $(".select2-school-select").select2({tags: true});  // Allow custom options for school
+
+    // Properly style any pre-filled selects
+    $.each(selects, (i, e) => {
+        if (e.value) {
+            $(e).siblings("label").addClass("label-active");
+        }
+    });
+
+    selects.on("select2:opening", function () {
+        $(this).siblings("label").addClass("label-active");
+    });
+
+    selects.on("select2:closing", function (e) {
+        if (!this.value) {
+            $(this).siblings("label").removeClass("label-active");
+        }
+
+        // steal focus during close - only capture once and stop propogation
+        // https://stackoverflow.com/a/49261426/3882202
+        $(e.target).data("select2").$selection.one("focus focusin", function (e) {
+            e.stopPropagation();
+        });
+    });
+
+    // on first focus (bubbles up to document), open the menu
+    // https://stackoverflow.com/a/49261426/3882202
+    $(document).on('focus', '.select2-selection.select2-selection--single', function () {
+      $(this).closest(".select2-container").siblings('select:enabled').select2('open');
+    });
+});
+
+</script>
+{% endblock %}

--- a/hackathon_site/review/jinja2/review/send-decisions.html
+++ b/hackathon_site/review/jinja2/review/send-decisions.html
@@ -6,35 +6,21 @@
 {% set form_action=url("admin:send-decision-emails") %}
 
 {% block form_description %}
-    {% if form.non_field_errors %}
-        <div class="row col s12">
-        {% for error in form.non_field_errors() %}
-            <span class="formError">{{ error }}</span>
-        {% endfor %}
-        </div>
+    <div class="row col s12">
+    {% for error in form.non_field_errors() %}
+        <span class="formError">{{ error }}</span>
+    {% endfor %}
+    </div>
         <div class="row col s12">
             Accepted: {{ accepted_count }}
             Waitlisted: {{ waitlisted_count }}
             Rejected: {{ rejected_count }}
         </div>
-    {% endif %}
 {% endblock %}
 
 {% block form_inputs %}
     {% for field in form %}
-        {% if field.field.widget.input_type == "select" %}
-            <div class="input-field row col s12">
-                <select id="status" name="status">
-                    <option value="" disabled selected>Choose your option</option>
-                    <option value="Accepted">Accepted</option>
-                    <option value="Waitlisted">Waitlisted</option>
-                    <option value="Rejected">Rejected</option>
-                </select>
-                <label>{{field.label}}</label>
-            </div>
-        {% else %}
-            {{ render_field(field, size="s12") }}
-        {% endif %}
+        {{ render_field(field, size="s12") }}
     {% endfor %}
 {% endblock %}
 

--- a/hackathon_site/review/jinja2/review/send-decisions.html
+++ b/hackathon_site/review/jinja2/review/send-decisions.html
@@ -1,19 +1,11 @@
 {% extends "event/form_base.html" %}
 
 {% block form_title %}SEND DECISION EMAILS TO PARTICIPANTS{% endblock %}
-{% block form_attrs %}enctype="multipart/form-data"{% endblock %}
 
 {% set form_action=url("admin:send-decision-emails") %}
 
 {% block form_description %}
-    {% if form.non_field_errors() %}
-        <div class="row col s12">
-        {% for error in form.non_field_errors() %}
-            <span class="formError">{{ error }}</span>
-        {% endfor %}
-        </div>
-    {% endif %}
-    <div class="row col s12">
+    <div>
         Accepted: {{ accepted_count }}
         Waitlisted: {{ waitlisted_count }}
         Rejected: {{ rejected_count }}

--- a/hackathon_site/review/templates/review/change_list.html
+++ b/hackathon_site/review/templates/review/change_list.html
@@ -9,6 +9,7 @@
 &rsaquo; {{ cl.opts.verbose_name_plural|capfirst }}
     {% if has_change_permission %}
     <a class="button" style="float: right; margin: -4px 15px -4px -5px;" href="{% url 'admin:assign-reviewer-to-team' %}">Review Next Team</a>
+        <a class="button" style="float: right; margin: -4px 15px -4px -5px;" href="{% url 'admin:send-decision-emails' %}">Send Decisions</a>
     {% endif %}
 </div>
 {% endblock %}

--- a/hackathon_site/review/templates/review/change_list.html
+++ b/hackathon_site/review/templates/review/change_list.html
@@ -9,7 +9,9 @@
 &rsaquo; {{ cl.opts.verbose_name_plural|capfirst }}
     {% if has_change_permission %}
     <a class="button" style="float: right; margin: -4px 15px -4px -5px;" href="{% url 'admin:assign-reviewer-to-team' %}">Review Next Team</a>
-        <a class="button" style="float: right; margin: -4px 15px -4px -5px;" href="{% url 'admin:send-decision-emails' %}">Send Decisions</a>
+    {% endif %}
+    {% if request.user.is_superuser %}
+    <a class="button" style="float: right; margin: -4px 15px -4px -5px;" href="{% url 'admin:send-decision-emails' %}">Send Decisions</a>
     {% endif %}
 </div>
 {% endblock %}

--- a/hackathon_site/review/tests.py
+++ b/hackathon_site/review/tests.py
@@ -215,7 +215,7 @@ class MailerTestCase(SetupUserMixin, TestCase):
             mail.outbox[0].subject,
         )
         self.assertIn(
-            f"The {settings.HACKATHON_NAME} team has reviewed your application, and we’re excited to welcome you to CoolHacks!",
+            f"The {settings.HACKATHON_NAME} team has reviewed your application, and we’re excited to welcome you to {settings.HACKATHON_NAME}!",
             clean_mail_body,
         )
 

--- a/hackathon_site/review/views.py
+++ b/hackathon_site/review/views.py
@@ -32,8 +32,12 @@ class MailerView(UserPassesTestMixin, FormView):
         (with last_updated_date) between date_start and date_end. The number of emails
         for that status that will be sent is dictated by the quantity.
         """
-        date_start = form.cleaned_data["date_start"]
-        date_end = form.cleaned_data["date_end"]
+        date_start = datetime.combine(
+            form.cleaned_data["date_start"], datetime.min.time()
+        ).replace(tzinfo=settings.TZ_INFO)
+        date_end = datetime.combine(
+            form.cleaned_data["date_end"], datetime.max.time()
+        ).replace(tzinfo=settings.TZ_INFO)
         status = form.cleaned_data["status"]
         quantity = form.cleaned_data["quantity"]
 

--- a/hackathon_site/review/views.py
+++ b/hackathon_site/review/views.py
@@ -11,6 +11,9 @@ from django.core import mail
 from review.forms import MailerForm
 from review.models import Review
 from hackathon_site import settings
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class MailerView(UserPassesTestMixin, FormView):
@@ -71,6 +74,7 @@ class MailerView(UserPassesTestMixin, FormView):
                 review.decision_sent_date = datetime.now().date()
                 review.save()
         except Exception as e:
+            logger.error(e)
             raise e
         finally:
             connection.close()

--- a/hackathon_site/review/views.py
+++ b/hackathon_site/review/views.py
@@ -1,3 +1,93 @@
-from django.shortcuts import render
+from datetime import datetime, timedelta
 
-# Create your views here.
+from django.urls import reverse_lazy
+from django.shortcuts import redirect
+from django.views.generic.edit import FormView
+from django.contrib.auth.mixins import UserPassesTestMixin
+
+from django.template.loader import render_to_string
+from django.core import mail
+
+from review.forms import MailerForm
+from review.models import Review
+from hackathon_site import settings
+
+
+class MailerView(UserPassesTestMixin, FormView):
+    template_name = "review/send-decisions.html"
+    success_url = reverse_lazy("admin:send-decision-emails")
+
+    def test_func(self):
+        return self.request.user.is_superuser
+
+    def get_form(self, form_class=None):
+        return MailerForm(**self.get_form_kwargs())
+
+    def form_valid(self, form, **kwargs):
+        """
+        On form submission valid get the data and send emails depending on the status.
+
+        Accepted / Waitlisted / Rejected emails will be sent for applications reviewed
+        (with last_updated_date) between date_start and date_end. The number of emails
+        for that status that will be sent is dictated by the quantity.
+        """
+        date_start = form.cleaned_data["date_start"]
+        date_end = form.cleaned_data["date_end"]
+        status = form.cleaned_data["status"]
+        quantity = form.cleaned_data["quantity"]
+
+        queryset = Review.objects.filter(
+            status=status,
+            updated_at__gte=date_start,
+            updated_at__lte=date_end,
+            decision_sent_date__isnull=True,
+        ).all()[:quantity]
+
+        # Get a mail socket connection and manually open it
+        connection = mail.get_connection(fail_silently=False)
+        connection.open()
+
+        for review in queryset:
+            email = mail.EmailMessage(
+                render_to_string(f"review/emails/{status.lower()}_email_subject.txt"),
+                render_to_string(
+                    f"review/emails/{status.lower()}_email_body.html",
+                    {  # Pass context data to the template
+                        "user": review.application.user,
+                        "request": self.request,
+                        "rsvp_deadline": (
+                            datetime.now().date() + timedelta(days=settings.RSVP_DAYS)
+                        ).strftime("%b %d %Y"),
+                    },
+                ),
+                settings.DEFAULT_FROM_EMAIL,
+                [review.application.user.email_user],
+                connection=connection,
+            )
+            email.send()
+
+            review.decision_sent_date = datetime.now().date()
+            review.save()
+        connection.close()
+
+        return redirect(self.get_success_url())
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        context["accepted_count"] = Review.objects.filter(
+            decision_sent_date__isnull=True, status="Accepted"
+        ).count()
+
+        context["waitlisted_count"] = Review.objects.filter(
+            decision_sent_date__isnull=True, status="Waitlisted"
+        ).count()
+
+        context["rejected_count"] = Review.objects.filter(
+            decision_sent_date__isnull=True, status="Rejected"
+        ).count()
+
+        return context
+
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)


### PR DESCRIPTION
## Overview

- Resolves #184 
- Creates a template for sending emails using the django admin site
- Creates a link in the top bar of the admin site when in `Review --> Teams` that takes you to the page to send decisions. Decisions can only be sent by superusers
- Can see number of Accepted, Waitlisted, Rejected people left to send emails to

## Unit Tests Created

- Check permissions for only superusers allowed to access page
- Send emails to Accepted, Waitlisted, Rejected and check that the correct amount are sent
- Send emails to Accepted, Waitlisted, Rejected and check that the text is correct in the subject and body

## Steps to QA

- Create some users and reviews and send various emails to them using the system. Make sure you do this as a superuser. 
- You should be able to see the emails in your console. Make sure the text is correct based on the status of the users you are sending emails for
- Make sure the number of emails sent corresponds to the number of emails you entered to send on the form
- Try sending with a date constraint and make sure it only sends emails to those users that were reviewed within those days.

