### PR TITLE
added hackthon chat/link tuple

### DIFF
--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -176,7 +176,7 @@
             <p class="faqAnswer">Your team number is just for your application so we can review your team together. It is not deciding and not needed during the event. You have until the event to choose a team and must submit to Devpost with the final team.</p>
 
             <p class="faqQuestion">I don’t have a team. What can I do?</p>
-            <p class="faqAnswer">All teams competing must have 3 or 4 members, but you do not need a full team in order to apply. We have a #team-formation channel on {{ chat_room_name }} as well as a team formation event scheduled before hacking starts at the event.</p>
+            <p class="faqAnswer">All teams competing must have 3 or 4 members, but you do not need a full team in order to apply. We have a channel on {{ chat_room_name }} dedicated to team formation as well as an event scheduled before hacking starts at the event.</p>
 
             <p class="faqQuestion">Are decisions unanimous for a team?</p>
             <p class="faqAnswer">Due to the large number of applicants and limited number of spots for {{ hackathon_name }}, decisions may not be unanimous. Each member should expect an email regarding their individual decisions.</p>

--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -44,7 +44,7 @@
 
                     {% if application.rsvp %}
                         <p>Make sure you read the <a class="primaryText hoverLink" href="{{ participant_package_link }}" rel="noopener" target="_blank">participant package</a> for all the info regarding
-                            the event, and join our <a class="primaryText hoverLink" href="{{ chat_room_link }}" rel="noopener" target="_blank">Slack</a>. Stay tuned for more updates regarding detailed event logistics, and we hope to see you soon!</p> <br />
+                            the event, and join our <a class="primaryText hoverLink" href="{{ chat_room_link }}" rel="noopener" target="_blank"> {{ chat_room_name }}</a>. Stay tuned for more updates regarding detailed event logistics, and we hope to see you soon!</p> <br />
                     {% endif %}
                     <p>If you have questions, read the <a class="primaryText hoverLink" href="#faq">FAQ</a>, or feel free to contact us.</p> <br />
 
@@ -176,7 +176,7 @@
             <p class="faqAnswer">Your team number is just for your application so we can review your team together. It is not deciding and not needed during the event. You have until the event to choose a team and must submit to Devpost with the final team.</p>
 
             <p class="faqQuestion">I don’t have a team. What can I do?</p>
-            <p class="faqAnswer">All teams competing must have 3 or 4 members, but you do not need a full team in order to apply. We have a #team-formation channel on Slack as well as a team formation event scheduled before hacking starts at the event.</p>
+            <p class="faqAnswer">All teams competing must have 3 or 4 members, but you do not need a full team in order to apply. We have a #team-formation channel on {{ chat_room_name }} as well as a team formation event scheduled before hacking starts at the event.</p>
 
             <p class="faqQuestion">Are decisions unanimous for a team?</p>
             <p class="faqAnswer">Due to the large number of applicants and limited number of spots for {{ hackathon_name }}, decisions may not be unanimous. Each member should expect an email regarding their individual decisions.</p>

--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -44,7 +44,7 @@
 
                     {% if application.rsvp %}
                         <p>Make sure you read the <a class="primaryText hoverLink" href="{{ participant_package_link }}" rel="noopener" target="_blank">participant package</a> for all the info regarding
-                            the event, and join our <a class="primaryText hoverLink" href="{{ chat_room_link }}" rel="noopener" target="_blank"> {{ chat_room_name }}</a>. Stay tuned for more updates regarding detailed event logistics, and we hope to see you soon!</p> <br />
+                            the event, and join our <a class="primaryText hoverLink" href="{{ chat_room_link }}" rel="noopener" target="_blank">{{ chat_room_name }}</a>. Stay tuned for more updates regarding detailed event logistics, and we hope to see you soon!</p> <br />
                     {% endif %}
                     <p>If you have questions, read the <a class="primaryText hoverLink" href="#faq">FAQ</a>, or feel free to contact us.</p> <br />
 

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -188,9 +188,6 @@ class DashboardTestCase(SetupUserMixin, TestCase):
             response, f"You've been accepted into {settings.HACKATHON_NAME}!"
         )
 
-        self.assertContains(response, f"{settings.CHAT_ROOM[0]}")
-        self.assertContains(response, f"{settings.CHAT_ROOM[1]}")
-
         # Buttons for RSVP appear
         self.assertContains(
             response, reverse("registration:rsvp", kwargs={"rsvp": "yes"})
@@ -272,7 +269,6 @@ class DashboardTestCase(SetupUserMixin, TestCase):
         self.assertContains(response, f"{settings.CHAT_ROOM[0]}")
         self.assertContains(response, f"{settings.CHAT_ROOM[1]}")
 
-        print(response)
         # Buttons for RSVP still appear
         self.assertContains(
             response, reverse("registration:rsvp", kwargs={"rsvp": "yes"})

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -212,7 +212,7 @@ class DashboardTestCase(SetupUserMixin, TestCase):
         self.assertContains(
             response, f"You've been waitlisted for {settings.HACKATHON_NAME}"
         )
-
+        self.assertContains(response, f"and join our {settings.CHAT_ROOM_TUPLE[0]}")
         # Buttons for RSVP don't appear
         self.assertNotContains(
             response, reverse("registration:rsvp", kwargs={"rsvp": "yes"})

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -188,6 +188,9 @@ class DashboardTestCase(SetupUserMixin, TestCase):
             response, f"You've been accepted into {settings.HACKATHON_NAME}!"
         )
 
+        self.assertContains(response, f"{settings.CHAT_ROOM[0]}")
+        self.assertContains(response, f"{settings.CHAT_ROOM[1]}")
+
         # Buttons for RSVP appear
         self.assertContains(
             response, reverse("registration:rsvp", kwargs={"rsvp": "yes"})
@@ -265,10 +268,9 @@ class DashboardTestCase(SetupUserMixin, TestCase):
         self.assertContains(
             response, f"You've been accepted into {settings.HACKATHON_NAME}!"
         )
-        self.assertContains(response, f"and join our")
-        self.assertContains(response, f"Slack")
-        # self.assertContains(response, f"and join our Slack")
-        self.assertContains(response, f"and join our {settings.CHAT_ROOM_NAME}")
+
+        self.assertContains(response, f"{settings.CHAT_ROOM[0]}")
+        self.assertContains(response, f"{settings.CHAT_ROOM[1]}")
 
         print(response)
         # Buttons for RSVP still appear

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -212,7 +212,6 @@ class DashboardTestCase(SetupUserMixin, TestCase):
         self.assertContains(
             response, f"You've been waitlisted for {settings.HACKATHON_NAME}"
         )
-        self.assertContains(response, f"and join our {settings.CHAT_ROOM_TUPLE[0]}")
         # Buttons for RSVP don't appear
         self.assertNotContains(
             response, reverse("registration:rsvp", kwargs={"rsvp": "yes"})
@@ -266,7 +265,12 @@ class DashboardTestCase(SetupUserMixin, TestCase):
         self.assertContains(
             response, f"You've been accepted into {settings.HACKATHON_NAME}!"
         )
+        self.assertContains(response, f"and join our")
+        self.assertContains(response, f"Slack")
+        # self.assertContains(response, f"and join our Slack")
+        self.assertContains(response, f"and join our {settings.CHAT_ROOM_NAME}")
 
+        print(response)
         # Buttons for RSVP still appear
         self.assertContains(
             response, reverse("registration:rsvp", kwargs={"rsvp": "yes"})

--- a/hackathon_site/hackathon_site/jinja2.py
+++ b/hackathon_site/hackathon_site/jinja2.py
@@ -32,7 +32,8 @@ def environment(**options):
             "from_email": settings.DEFAULT_FROM_EMAIL,
             "contact_email": settings.CONTACT_EMAIL,
             "participant_package_link": settings.PARTICIPANT_PACKAGE_LINK,
-            "chat_room_link": settings.CHAT_ROOM_LINK,
+            "chat_room_name": settings.CHAT_ROOM_TUPLE[0],
+            "chat_room_link": settings.CHAT_ROOM_TUPLE[1],
         }
     )
     return env

--- a/hackathon_site/hackathon_site/jinja2.py
+++ b/hackathon_site/hackathon_site/jinja2.py
@@ -32,8 +32,8 @@ def environment(**options):
             "from_email": settings.DEFAULT_FROM_EMAIL,
             "contact_email": settings.CONTACT_EMAIL,
             "participant_package_link": settings.PARTICIPANT_PACKAGE_LINK,
-            "chat_room_name": settings.CHAT_ROOM_TUPLE[0],
-            "chat_room_link": settings.CHAT_ROOM_TUPLE[1],
+            "chat_room_name": settings.CHAT_ROOM_NAME,
+            "chat_room_link": settings.CHAT_ROOM_LINK,
         }
     )
     return env

--- a/hackathon_site/hackathon_site/jinja2.py
+++ b/hackathon_site/hackathon_site/jinja2.py
@@ -32,8 +32,8 @@ def environment(**options):
             "from_email": settings.DEFAULT_FROM_EMAIL,
             "contact_email": settings.CONTACT_EMAIL,
             "participant_package_link": settings.PARTICIPANT_PACKAGE_LINK,
-            "chat_room_name": settings.CHAT_ROOM_NAME,
-            "chat_room_link": settings.CHAT_ROOM_LINK,
+            "chat_room_name": settings.CHAT_ROOM[0],
+            "chat_room_link": settings.CHAT_ROOM[1],
         }
     )
     return env

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -275,4 +275,4 @@ PARTICIPANT_PACKAGE_LINK = "#"
 
 # Note this is in the form (chat_room_name, chat_room_link)
 # Chat room name is such as the following: Slack, Discord
-CHAT_ROOM = ("https://slack.com, Slack")
+CHAT_ROOM = ("https://slack.com", "Slack")

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -275,4 +275,4 @@ PARTICIPANT_PACKAGE_LINK = "#"
 
 # Note this is in the form (chat_room_name, chat_room_link)
 # Chat room name is such as the following: Slack, Discord
-CHAT_ROOM = "https://slack.com, Slack"
+CHAT_ROOM = ("https://slack.com, Slack")

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -233,4 +233,7 @@ FINAL_REVIEW_RESPONSE_DATE = REGISTRATION_CLOSE_DATE + timedelta(days=7)
 
 # Links
 PARTICIPANT_PACKAGE_LINK = "#"
-CHAT_ROOM_LINK = "#"
+
+# Note this is in the form (chat_room_name, chat_room_link)
+# Chat room name is such as the following: Slack, Discord
+CHAT_ROOM_TUPLE = ("#", "#")

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -236,5 +236,4 @@ PARTICIPANT_PACKAGE_LINK = "#"
 
 # Note this is in the form (chat_room_name, chat_room_link)
 # Chat room name is such as the following: Slack, Discord
-CHAT_ROOM_NAME = "Slack"
-CHAT_ROOM_LINK = "slack.com"
+CHAT_ROOM = "https://slack.com, Slack"

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -236,4 +236,5 @@ PARTICIPANT_PACKAGE_LINK = "#"
 
 # Note this is in the form (chat_room_name, chat_room_link)
 # Chat room name is such as the following: Slack, Discord
-CHAT_ROOM_TUPLE = ("#", "#")
+CHAT_ROOM_NAME = "Slack"
+CHAT_ROOM_LINK = "slack.com"

--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -275,4 +275,4 @@ PARTICIPANT_PACKAGE_LINK = "#"
 
 # Note this is in the form (chat_room_name, chat_room_link)
 # Chat room name is such as the following: Slack, Discord
-CHAT_ROOM = ("https://slack.com", "Slack")
+CHAT_ROOM = ("Slack", "https://slack.com")

--- a/hackathon_site/review/jinja2/review/emails/accepted_email_body.html
+++ b/hackathon_site/review/jinja2/review/emails/accepted_email_body.html
@@ -5,7 +5,7 @@
 <p>The {{ hackathon_name }} team has reviewed your application, and we’re excited to welcome you to {{ hackathon_name }}! 
 To confirm your attendance, visit your <a href="{{ dashboard_url }}">dashboard</a> to RSVP by {{ rsvp_deadline }} otherwise your spot will be given to other applicants. Alternatively, you can press the "Cannot attend" button.</p>
 
-<p>Read our <a href="{{ participant_package_link }}">participant package</a> for all the info regarding the event, and join our <a href="{{ chat_room_link }}">Slack</a>. Stay tuned for more updates regarding detailed event logistics, and we hope to see you soon! If you have questions, read the FAQ on your <a href="{{ dashboard_url }}">dashboard</a> or feel free to contact us. </p>
+<p>Read our <a href="{{ participant_package_link }}">participant package</a> for all the info regarding the event, and join our <a href="{{ chat_room_link }}">{{ chat_room_name }}</a>. Stay tuned for more updates regarding detailed event logistics, and we hope to see you soon! If you have questions, read the FAQ on your <a href="{{ dashboard_url }}">dashboard</a> or feel free to contact us. </p>
 
 <p>Happy hacking,<br>
 The {{ hackathon_name }} Team

--- a/hackathon_site/review/tests.py
+++ b/hackathon_site/review/tests.py
@@ -209,7 +209,8 @@ class MailerTestCase(SetupUserMixin, TestCase):
         self.assertIn(rsvp_deadline, mail.outbox[0].body)
         self.assertIn(settings.HACKATHON_NAME, mail.outbox[0].body)
         self.assertIn(settings.PARTICIPANT_PACKAGE_LINK, mail.outbox[0].body)
-        self.assertIn(settings.CHAT_ROOM_LINK, mail.outbox[0].body)
+        self.assertIn(settings.CHAT_ROOM[0], mail.outbox[0].body)
+        self.assertIn(settings.CHAT_ROOM[1], mail.outbox[0].body)
         self.assertIn(
             f"Congratulations, you’ve been accepted to { settings.HACKATHON_NAME }",
             mail.outbox[0].subject,


### PR DESCRIPTION
## Overview

- Resolves #206 
- Added tuple to hold chat name (discord, slack, etc) and link in global jinja settings.
- updated dashboard and email templates to use these new variables


## Unit Tests Created

- No new tests created

## Steps to QA

- Run django and yarn tests
- Run server and check on view

