### PR TITLE
Send to proper email

### DIFF
--- a/hackathon_site/hackathon_site/tests.py
+++ b/hackathon_site/hackathon_site/tests.py
@@ -69,27 +69,60 @@ class SetupUserMixin:
         if self_users:
             user1 = self.user
             user2 = self.user2 = User.objects.create_user(
-                username="frank@johnston.com", password="hellothere31415"
+                username="frank@johnston.com",
+                password="hellothere31415",
+                email="frank@johnston.com",
+                first_name="Frank",
+                last_name="Johnston",
             )
             user3 = self.user3 = User.objects.create_user(
-                username="franklin@carmichael.com", password="supersecret456"
+                username="franklin@carmichael.com",
+                password="supersecret456",
+                email="franklin@carmichael.com",
+                first_name="Franklin",
+                last_name="Carmichael",
             )
             user4 = self.user4 = User.objects.create_user(
-                username="lawren@harris.com", password="wxyz7890"
+                username="lawren@harris.com",
+                password="wxyz7890",
+                email="lawren@harris.com",
+                first_name="Lawren",
+                last_name="Harris",
             )
         else:
             # Make some random users
+            email1 = self._get_random_email()
+            email2 = self._get_random_email()
+            email3 = self._get_random_email()
+            email4 = self._get_random_email()
+
             user1 = User.objects.create_user(
-                username=self._get_random_email(), password="foobar123"
+                username=email1,
+                password="foobar123",
+                email=email1,
+                first_name="John1",
+                last_name="Doe1",
             )
             user2 = User.objects.create_user(
-                username=self._get_random_email(), password="foobar123"
+                username=email2,
+                password="foobar123",
+                email=email2,
+                first_name="John2",
+                last_name="Doe2",
             )
             user3 = User.objects.create_user(
-                username=self._get_random_email(), password="foobar123"
+                username=email3,
+                password="foobar123",
+                email=email3,
+                first_name="John3",
+                last_name="Doe3",
             )
             user4 = User.objects.create_user(
-                username=self._get_random_email(), password="foobar123"
+                username=email4,
+                password="foobar123",
+                email=email4,
+                first_name="John4",
+                last_name="Doe4",
             )
 
         self._apply_as_user(user1, team)

--- a/hackathon_site/review/tests.py
+++ b/hackathon_site/review/tests.py
@@ -10,7 +10,7 @@ from hackathon_site.tests import SetupUserMixin
 from django.contrib.auth.models import Permission
 from django.db.models import Q
 from rest_framework import status
-from review.models import Review
+from review.models import Review, User
 
 
 class MailerTestCase(SetupUserMixin, TestCase):
@@ -189,6 +189,18 @@ class MailerTestCase(SetupUserMixin, TestCase):
         self.assertRedirects(response, self.view)
         self.assertEqual(quantity_before, quantity_after + 7)
 
+        expected_users = User.objects.filter(
+            application__review__updated_at__gte=self.form_data["date_start"],
+            application__review__updated_at__lte=self.form_data["date_end"],
+            application__review__decision_sent_date__isnull=True,
+            application__review__status=self.form_data["status"],
+        )
+
+        emailed_users = [email.to[0] for email in mail.outbox]
+
+        for user in expected_users:
+            self.assertIn(user.email, emailed_users)
+
     def test_correct_text_in_accepted_email(self):
         self._login()
         self._create_teams_and_reviews_for_mail_tests()
@@ -218,6 +230,9 @@ class MailerTestCase(SetupUserMixin, TestCase):
             f"The {settings.HACKATHON_NAME} team has reviewed your application, and we’re excited to welcome you to {settings.HACKATHON_NAME}!",
             clean_mail_body,
         )
+
+        # Check that email was passed in correctly is a real user
+        self.assertTrue(User.objects.filter(email=mail.outbox[0].to[0]).exists())
 
     def test_correct_text_in_waitlisted_email(self):
         self._login()

--- a/hackathon_site/review/views.py
+++ b/hackathon_site/review/views.py
@@ -55,10 +55,10 @@ class MailerView(UserPassesTestMixin, FormView):
         try:
             for review in queryset:
                 email = mail.EmailMessage(
-                    render_to_string(
+                    subject=render_to_string(
                         f"review/emails/{status.lower()}_email_subject.txt"
                     ),
-                    render_to_string(
+                    body=render_to_string(
                         f"review/emails/{status.lower()}_email_body.html",
                         {  # Pass context data to the template
                             "user": review.application.user,
@@ -69,8 +69,8 @@ class MailerView(UserPassesTestMixin, FormView):
                             ).strftime("%b %d %Y"),
                         },
                     ),
-                    settings.DEFAULT_FROM_EMAIL,
-                    [review.application.user.email_user],
+                    from_email=settings.DEFAULT_FROM_EMAIL,
+                    to=[review.application.user.email],
                     connection=connection,
                 )
                 email.send()


### PR DESCRIPTION
## Overview

- Resolves #216 
- Updates the review mailer to send to `user.email` instead of `user.email_user`


## Unit Tests Created
- Nothing new, but test that emails get sent to the right people and implicitly that email addresses work

## Steps to QA
- Send an email, make sure that the email in the To field in the console works
