### PR TITLE
Change Acceptance/Waitlisted/Rejected Email Sending

### DIFF
--- a/hackathon_site/review/tests.py
+++ b/hackathon_site/review/tests.py
@@ -190,8 +190,12 @@ class MailerTestCase(SetupUserMixin, TestCase):
         self.assertEqual(quantity_before, quantity_after + 7)
 
         expected_users = User.objects.filter(
-            application__review__updated_at__gte=self.form_data["date_start"],
-            application__review__updated_at__lte=self.form_data["date_end"],
+            application__review__updated_at__gte=datetime.combine(
+                self.form_data["date_start"], datetime.min.time()
+            ).replace(tzinfo=settings.TZ_INFO),
+            application__review__updated_at__lte=datetime.combine(
+                self.form_data["date_end"], datetime.max.time()
+            ).replace(tzinfo=settings.TZ_INFO),
             application__review__decision_sent_date__isnull=True,
             application__review__status=self.form_data["status"],
         )

--- a/hackathon_site/review/views.py
+++ b/hackathon_site/review/views.py
@@ -54,36 +54,35 @@ class MailerView(UserPassesTestMixin, FormView):
 
         try:
             for review in queryset:
+                current_date = datetime.now().date()
+
+                # Create context data for rendering the template. Note that this assumes that both the message
+                # and html_message have identical context data
+                render_to_string_context = {
+                    "user": review.application.user,
+                    "request": self.request,
+                    "rsvp_deadline": (
+                        current_date + timedelta(days=settings.RSVP_DAYS)
+                    ).strftime("%b %d %Y"),
+                }
+
                 review.application.user.email_user(
                     subject=render_to_string(
                         f"review/emails/{status.lower()}_email_subject.txt"
                     ),
                     message=render_to_string(
                         f"review/emails/{status.lower()}_email_body.html",
-                        {  # Pass context data to the template
-                            "user": review.application.user,
-                            "request": self.request,
-                            "rsvp_deadline": (
-                                datetime.now().date()
-                                + timedelta(days=settings.RSVP_DAYS)
-                            ).strftime("%b %d %Y"),
-                        },
+                        render_to_string_context,  # Pass context data to the template
                     ),
                     html_message=render_to_string(
                         f"review/emails/{status.lower()}_email_body.html",
-                        {  # Pass context data to the template
-                            "user": review.application.user,
-                            "request": self.request,
-                            "rsvp_deadline": (
-                                datetime.now().date()
-                                + timedelta(days=settings.RSVP_DAYS)
-                            ).strftime("%b %d %Y"),
-                        },
+                        render_to_string_context,  # Pass context data to the template
                     ),
                     from_email=settings.DEFAULT_FROM_EMAIL,
                     connection=connection,
                 )
-                review.decision_sent_date = datetime.now().date()
+
+                review.decision_sent_date = current_date
                 review.save()
         except Exception as e:
             logger.error(e)


### PR DESCRIPTION
## Overview

- Resolves #218 
- Changes Acceptance/Waitlisted/Rejected Email sending to use `user.email_user` instead of `EmailMessage`
- Passes in the template string for both the `message` parameter and the `html_message` parameter. Note that this means if the email client a user uses doesn't support HTML messages, it will show raw HTML
- Added datetime format to a unit test so it doesn't throw warnings when running tests

## Unit Tests Created

- Just ran same unit tests as before

## Steps to QA

- Whatever floats your boat
