### PR TITLE
Switch the CI/CD workflow to run on PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI/CD
 
 on:
-  push:
+  pull_request:
     branches: '**'
 
 jobs:


### PR DESCRIPTION
## Overview
- Switches the CI/CD workflow to run on PRs, rather than pushes. 
- This means that jobs won't be run on branches until a PR is open, but should now support running jobs from forks

