### PR TITLE
Update docker-compose.yml with postgres volume and container names

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -3,14 +3,19 @@ version: '3'
 services:
     postgres:
         image: postgres:12.2
+        container_name: hackathon-template_postgres
         ports:
             - 5432:5432
         environment:
             - POSTGRES_DB=hackathon_site
             - POSTGRES_HOST_AUTH_METHOD=trust
         volumes:
-            - ./.postgres-data:/var/lib/postgresql/data
+            - hackathon-template_postgres-data:/var/lib/postgresql/data
     redis:
         image: redis:6-alpine
+        container_name: hackathon-template_redis
         ports:
             - 6379:6379
+
+volumes:
+    hackathon-template_postgres-data:


### PR DESCRIPTION
## Overview

- Resolves #199
- Sets container names for the postgres and redis services
- Changes the local volume to a named volume for the postgres service, so that it works properly on Windows and Mac

## Steps to QA
- If you care about your local database, back it up first! Before checking out this branch, start the database container and run:
```bash
pg_dump -h 127.0.0.1 -p 5432 -U postgres hackathon_site > hackathon_site_bak.db
```
- Stop the container (and delete it), switch to this branch, and bring up the stack with `docker-compose -f development/docker-compose.yml up -d`
- Restore the database from the dump:
```bash
psql -d hackathon_site -h 127.0.0.1 -U postgres < hackathon_site_bak.db
```

