### PR TITLE
Remove asgiref from requirements.txt

### DIFF
--- a/hackathon_site/requirements.txt
+++ b/hackathon_site/requirements.txt
@@ -1,5 +1,4 @@
 appdirs==1.4.3
-asgiref==3.2.7
 attrs==19.3.0
 black==19.10b0
 certifi==2020.4.5.1


### PR DESCRIPTION
## Overview

- Resolves #223 
- Removes asgiref from requirements.txt to resolve a dependency conflict with Django. Django is the only thing that depends on it, so let pip resolve it.

## Steps to QA
- We don't actually use ASGI anywhere, so not much. See if the workflow starts passing again.

