### PR TITLE
Fixed admin squared count for team member count

### DIFF
--- a/hackathon_site/review/admin.py
+++ b/hackathon_site/review/admin.py
@@ -203,7 +203,7 @@ class TeamReviewAdmin(admin.ModelAdmin):
             .prefetch_related(
                 "applications", "applications__review", "applications__user"
             )
-            .annotate(members_count=Count("applications"))
+            .annotate(members_count=Count("applications", distinct=True))
             .annotate(most_recent_submission=Max("applications__updated_at"))
         )
 

--- a/hackathon_site/review/test_admin.py
+++ b/hackathon_site/review/test_admin.py
@@ -79,6 +79,20 @@ class TeamReviewListAdminTestCase(SetupUserMixin, TestCase):
         # More precise to look for this than just the number "3"
         self.assertContains(response, '<td class="field-get_members_count">3</td>')
 
+    def test_list_page_shows_team_member_count_with_filters(self):
+        """
+        Test that the admin page correctly counts the number of team members with filter
+        """
+        team = self._make_full_registration_team()
+        # Delete a user so there's only 3 members
+        self.user4.delete()
+        self._login(self.view_permissions)
+        response = self.client.get(f"{self.list_view}?reviewed=false")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertContains(response, team.team_code)
+        # More precise to look for this than just the number "3"
+        self.assertContains(response, '<td class="field-get_members_count">3</td>')
+
     def test_list_page_shows_submission_date(self):
         """
         The submission date for a team is the date of the most recently submitted


### PR DESCRIPTION
Made changes to `review/admin.py` and added a test to `review/test_admin.py`

## Overview

- Resolves #209 
- Added `distinct=True` in `Count()` in the class `TeamReviewAdmin` in `review/admin.py`
- Added a test case for team member count with filter in `review/test_admin.py`


## Unit Tests Created

- `test_list_page_shows_team_member_count_with_filters`
    - tests team member count with filter: `reviewed=false`


## Steps to QA

- Run Unit Test: 
    - `python manage.py test --settings=hackathon_site.settings.ci review.test_admin`
- Check on Admin site: Create a team for them under Registration > Teams (not event > teams, that's something else). Then create an application for each of them from Registration > Applications. Once that's all done, under Review > Teams you can enable the "Not reviewed" filter to make sure the members count is correct instead of squared 

