### PR TITLE
Change trigger in CI/CD workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI/CD
 
 on:
-  pull_request:
+  pull_request_target:
     branches: '**'
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request_target.head.ref}}
+          repository: ${{github.event.pull_request_target.head.repo.full_name}}
       - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
@@ -39,6 +42,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request_target.head.ref}}
+          repository: ${{github.event.pull_request_target.head.repo.full_name}}
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
@@ -56,6 +62,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request_target.head.ref}}
+          repository: ${{github.event.pull_request_target.head.repo.full_name}}
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ This will place static files in `hackathon_site/static/`. These must be served s
 ## Using this Template
 This repository is setup as a template. To read more about how to use a template and what a template repository is, see [GitHub's doc page](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template).
 
+Before you begin, note that the [main workflow file](https://github.com/ieeeuoft/hackathon-template/blob/develop/.github/workflows/main.yml) uses the `pull_request_target` trigger. This means that pull requests from forks will run workflows in the base branch, **and will have access to repository secrets**. For the base template repo, this is not a security concern since the only secret used in tests is `DJANGO_SECRET_KEY`, and is meaningless in this repository. However, an instance of this repository will likely have other secrets set. **Unless you are absolutely sure that code run by workflows for pull requests, such as tests, does not have access to important secrets, you should change this trigger type back to `pull_request`**. This means that pull requests from forks (of your fork) will not run actions. Alternatively, if tests only need access to secret keys so they don't complain, use a different secret in the workflow files for running tests.
+
 ### Forking
 If you are interested in receiving updates to this template in your project, we recommend that you fork this repository into your own account or organization. This will give you the entire commit history of the project, and will allow you to make pull requests from this repository into your own to perform updates.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IEEE Hackathon Website Template
 
-A website template for hackathons run by [IEEE University of Toronto Student Branch](https://ieee.utoronto.ca/).
+A website template for hackathons run by [IEEE University of Toronto Student Branch](https://ieee.utoronto.ca/). 
 
 ## Contents
 - [Requirements](#requirements)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IEEE Hackathon Website Template
 
-A website template for hackathons run by [IEEE University of Toronto Student Branch](https://ieee.utoronto.ca/). 
+A website template for hackathons run by [IEEE University of Toronto Student Branch](https://ieee.utoronto.ca/).
 
 ## Contents
 - [Requirements](#requirements)


### PR DESCRIPTION
## Overview

- Changes the trigger of the main workflow from `pull_request` to `pull_request_target`. This is largely the same, except actions get run on the base repository instead of the head - this means that secrets (`DJANGO_SECRET_KEY` in our case) can be used from the base repository, so all contributors don't need to set them up.
- This is motivated by #226, which is failing checks because the secret isn't set in their forked repo.
- Read more about the `pull_request_target` event [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target).