### PR TITLE
Create a test that fails

### DIFF
--- a/hackathon_site/event/test_api.py
+++ b/hackathon_site/event/test_api.py
@@ -15,7 +15,7 @@ class CurrentUserTestCase(SetupUserMixin, APITestCase):
         self.profile = Profile.objects.create(user=self.user)
 
         self.view = reverse("api:event:current-user")
-    
+
     def test_that_fails(self):
         self.assertTrue(False)
 

--- a/hackathon_site/event/test_api.py
+++ b/hackathon_site/event/test_api.py
@@ -15,6 +15,9 @@ class CurrentUserTestCase(SetupUserMixin, APITestCase):
         self.profile = Profile.objects.create(user=self.user)
 
         self.view = reverse("api:event:current-user")
+    
+    def test_that_fails(self):
+        self.assertTrue(False)
 
     def test_user_not_logged_in(self):
         response = self.client.get(self.view)


### PR DESCRIPTION
Just to make sure actions still run from the correct commit after switching to `pull_request_target` in #227 
