### PR TITLE
Update main.yml events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{github.event.pull_request_target.head.ref}}
-          repository: ${{github.event.pull_request_target.head.repo.full_name}}
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
@@ -43,8 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{github.event.pull_request_target.head.ref}}
-          repository: ${{github.event.pull_request_target.head.repo.full_name}}
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:
@@ -63,8 +63,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{github.event.pull_request_target.head.ref}}
-          repository: ${{github.event.pull_request_target.head.repo.full_name}}
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Use Node.js 12.x
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
## Overview
Changes `github.event.pull_request_target` to `github.event.pull_request` in the checkout actions. #229 shows that when using the `pull_request_target` event there, it checks out the base branch.

I've tested this in another repo, it should work as expected. In particular, I created this job:
```
jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
        with:
          ref: ${{github.event.pull_request.head.ref}}
          repository: ${{github.event.pull_request_target.head.repo.full_name}}
      - run: |
          echo "Pull request event:"
          echo "${{github.event.pull_request.head.ref}}"
          echo "${{github.event.pull_request.head.repo.full_name}}"
          echo "Pull request target event":
          echo "${{github.event.pull_request_target.head.ref}}"
          echo "${{github.event.pull_request_target.head.repo.full_name}}"
```

This is the output from the action:
![image](https://user-images.githubusercontent.com/26036279/100826376-2a6c2a00-3428-11eb-8c24-269360292457.png)

It seems that `github.event.pull_request_target` doesn't event exist, which I assume means that the action reverts to it's default (which for `pull_request_target` triggers is the check out the base branch).