### PR TITLE
fix that opens the offending select2 element

### DIFF
--- a/hackathon_site/event/static/event/styles/scss/select2.scss
+++ b/hackathon_site/event/static/event/styles/scss/select2.scss
@@ -180,11 +180,13 @@ THE SOFTWARE.
     border: 0 !important;
     clip: rect(0 0 0 0) !important;
     height: 1px !important;
-    margin: -1px !important;
+    margin: 0 auto;
     overflow: hidden !important;
     padding: 0 !important;
     position: absolute !important;
     width: 1px !important;
+    display: block;
+    opacity: 0;
 }
 .select2-container--default {
     .select2-selection--single {

--- a/hackathon_site/event/static/event/styles/scss/styles.scss
+++ b/hackathon_site/event/static/event/styles/scss/styles.scss
@@ -55,7 +55,7 @@ strong {
 .navbar {
     position: sticky;
     top: 0;
-    z-index: 998;
+    z-index: 1100;
 }
 // End of navbar stuff
 


### PR DESCRIPTION
## Overview

- Resolves #175 
- Changes to the css that removes the console log errors
- When user attempts to submit an empty select2, it opens up the select2 element alerting the user 
- Trade off: Does not show the usual "required" popups as other fields.


## Unit Tests Created

- None, css changes.


## Steps to QA

- Login into template site and create application at /registration/application/
- Fill any arrangement of inputs but leave at least one select2 empty
- Completed if empty select2 box always opens

