### PR TITLE
Make dashboard more clear when you RSVP

### DIFF
--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -32,20 +32,20 @@
             {% elif application is not none and review is not none %}
                 <br />
                 {% if review.status == "Accepted" %}
-                    {% if application.rsvp == True %}
+                    {% if application.rsvp %}
                         <h4 class="formH2"><b>Thanks for RSVP'ing!</b> See you at {{ hackathon_name }}!</h4>
-                    {% elif application.rsvp == False %}
+                    {% elif application.rsvp is False %}
                         <h4 class="formH2"><b>Thanks for letting us know.</b> Hope to see you next year at {{ hackathon_name }}</h4>
                     {% else %}
                         <h4 class="formH2"><b>Congratulations!</b> You've been accepted into {{ hackathon_name }}!</h4>
                     {% endif %}
                     <p style="display: flex;">
                         <strong>Status:&nbsp;</strong>
-                        {% if status == "Cannot Attend (Declined)" %} 
+                        {% if application.rsvp is False %} 
                             <span class="material-icons errorText" style="margin-right: 3px;">
                                 highlight_off
                             </span>
-                        {% elif status == "Will Attend (Accepted)" %} 
+                        {% elif application.rsvp %} 
                             <span class="material-icons successText" style="margin-right: 3px;">
                                 check_circle_outline
                             </span>
@@ -54,7 +54,7 @@
                     </p>
                     <br>
                     {% if not rsvp_passed %}
-                        {% if status == "Accepted, awaiting RSVP" %}
+                        {% if application.rsvp is None %}
                             <p>To confirm your attendance at {{ hackathon_name }}, please RSVP using the accept or decline buttons below.</p> <br />
                             <p>RSVP by <b>{{ rsvp_deadline }} (11:59PM EST)</b>, otherwise your spot will be given to other applicants.
                                 Alternatively you can decline the offer. You can change your response at any time before <b>{{ rsvp_deadline }} (11:59PM EST)</b>.
@@ -72,7 +72,7 @@
 
                     {% if not rsvp_passed %}
                         <div style="display: flex; width: auto">
-                            {% if status == "Cannot Attend (Declined)" or status == "Accepted, awaiting RSVP" %}
+                            {% if application.rsvp is False or application.rsvp is None %}
                             <a
                                 href="{{ url("registration:rsvp", kwargs={"rsvp": "yes"}) }}"
                                 class="btn-small waves-effect waves-light colorBtn"
@@ -81,7 +81,7 @@
                                 Will Attend (Accept)
                             </a>
                             {% endif %}
-                            {% if status == "Will Attend (Accepted)" or status == "Accepted, awaiting RSVP" %}
+                            {% if application.rsvp or application.rsvp is None %}
                             <a
                                 href="{{ url("registration:rsvp", kwargs={"rsvp": "no"})}}"
                                 class="btn-small waves-effect waves-light redBtn"
@@ -91,9 +91,9 @@
                             {% endif %}
                         </div>
 
-                    {% elif rsvp_passed and application.rsvp == True %}
+                    {% elif rsvp_passed and application.rsvp %}
                         <p><b>The RSVP deadline has passed. Thanks for confirming your position at {{ hackathon_name }}! We look forward to seeing you there. Note that you cannot change your RSVP at this time.</b></p>
-                    {% elif rsvp_passed and application.rsvp == False %}
+                    {% elif rsvp_passed and application.rsvp is False %}
                         <p><b>The RSVP deadline has passed. We regret to see that you will not be joining us this year at {{ hackathon_name }}. Unfortunately you cannot change your RSVP at this time.</b></p>
                     {% else %}
                         <p><b>It appears you haven't RSVPed. Unfortunately the RSVP deadline has passed and you cannot change your RSVP at this time.</b></p>

--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -54,10 +54,14 @@
                     </p>
                     <br>
                     {% if not rsvp_passed %}
-                        <p>To confirm your attendance at {{ hackathon_name }}, please RSVP using the accept or decline buttons below.</p> <br />
-                        <p>RSVP by <b>{{ rsvp_deadline }} (11:59PM EST)</b>, otherwise your spot will be given to other applicants.
-                            Alternatively you can decline the offer. You can change your response at any time before <b>{{ rsvp_deadline }} (11:59PM EST)</b>.
-                        </p> <br />
+                        {% if status == "Accepted, awaiting RSVP" %}
+                            <p>To confirm your attendance at {{ hackathon_name }}, please RSVP using the accept or decline buttons below.</p> <br />
+                            <p>RSVP by <b>{{ rsvp_deadline }} (11:59PM EST)</b>, otherwise your spot will be given to other applicants.
+                                Alternatively you can decline the offer. You can change your response at any time before <b>{{ rsvp_deadline }} (11:59PM EST)</b>.
+                            </p> <br />
+                        {% else %}
+                            <p>You can change your response at any time before <b>{{ rsvp_deadline }} (11:59PM EST)</b>.</p> <br />
+                        {% endif %}
                     {% endif %}
 
                     {% if application.rsvp %}
@@ -68,20 +72,23 @@
 
                     {% if not rsvp_passed %}
                         <div style="display: flex; width: auto">
+                            {% if status == "Cannot Attend (Declined)" or status == "Accepted, awaiting RSVP" %}
                             <a
                                 href="{{ url("registration:rsvp", kwargs={"rsvp": "yes"}) }}"
                                 class="btn-small waves-effect waves-light colorBtn"
+                                style="margin-right: 30px;"
                             >
                                 Will Attend (Accept)
                             </a>
-
+                            {% endif %}
+                            {% if status == "Will Attend (Accepted)" or status == "Accepted, awaiting RSVP" %}
                             <a
                                 href="{{ url("registration:rsvp", kwargs={"rsvp": "no"})}}"
                                 class="btn-small waves-effect waves-light redBtn"
-                                style="margin-left: 30px;"
                             >
                                 Cannot Attend (Decline)
                             </a>
+                            {% endif %}
                         </div>
 
                     {% elif rsvp_passed and application.rsvp == True %}

--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -32,8 +32,26 @@
             {% elif application is not none and review is not none %}
                 <br />
                 {% if review.status == "Accepted" %}
-                    <h4 class="formH2"><b>Congratulations!</b> You've been accepted into {{ hackathon_name }}!</h4>
-                    <p><strong>Status</strong>: {{ status }}</p>
+                    {% if application.rsvp == True %}
+                        <h4 class="formH2"><b>Thanks for RSVP'ing!</b> See you at {{ hackathon_name }}!</h4>
+                    {% elif application.rsvp == False %}
+                        <h4 class="formH2"><b>Thanks for letting us know.</b> Hope to see you next year at {{ hackathon_name }}</h4>
+                    {% else %}
+                        <h4 class="formH2"><b>Congratulations!</b> You've been accepted into {{ hackathon_name }}!</h4>
+                    {% endif %}
+                    <p style="display: flex;">
+                        <strong>Status:&nbsp;</strong>
+                        {% if status == "Cannot Attend (Declined)" %} 
+                            <span class="material-icons errorText" style="margin-right: 3px;">
+                                highlight_off
+                            </span>
+                        {% elif status == "Will Attend (Accepted)" %} 
+                            <span class="material-icons successText" style="margin-right: 3px;">
+                                check_circle_outline
+                            </span>
+                        {% endif %}
+                        {{ status }}
+                    </p>
                     <br>
                     {% if not rsvp_passed %}
                         <p>To confirm your attendance at {{ hackathon_name }}, please RSVP using the accept or decline buttons below.</p> <br />
@@ -66,9 +84,9 @@
                             </a>
                         </div>
 
-                    {% elif rsvp_passed and  application.rsvp == True %}
+                    {% elif rsvp_passed and application.rsvp == True %}
                         <p><b>The RSVP deadline has passed. Thanks for confirming your position at {{ hackathon_name }}! We look forward to seeing you there. Note that you cannot change your RSVP at this time.</b></p>
-                    {% elif rsvp_passed and  application.rsvp == False %}
+                    {% elif rsvp_passed and application.rsvp == False %}
                         <p><b>The RSVP deadline has passed. We regret to see that you will not be joining us this year at {{ hackathon_name }}. Unfortunately you cannot change your RSVP at this time.</b></p>
                     {% else %}
                         <p><b>It appears you haven't RSVPed. Unfortunately the RSVP deadline has passed and you cannot change your RSVP at this time.</b></p>

--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -34,14 +34,14 @@
                 {% if review.status == "Accepted" %}
                     {% if application.rsvp %}
                         <h4 class="formH2"><b>Thanks for RSVP'ing!</b> See you at {{ hackathon_name }}!</h4>
-                    {% elif application.rsvp is False %}
+                    {% elif application.rsvp is sameas false %}
                         <h4 class="formH2"><b>Thanks for letting us know.</b> Hope to see you next year at {{ hackathon_name }}</h4>
                     {% else %}
                         <h4 class="formH2"><b>Congratulations!</b> You've been accepted into {{ hackathon_name }}!</h4>
                     {% endif %}
                     <p style="display: flex;">
                         <strong>Status:&nbsp;</strong>
-                        {% if application.rsvp is False %} 
+                        {% if application.rsvp is sameas false %} 
                             <span class="material-icons errorText" style="margin-right: 3px;">
                                 highlight_off
                             </span>
@@ -54,7 +54,7 @@
                     </p>
                     <br>
                     {% if not rsvp_passed %}
-                        {% if application.rsvp is None %}
+                        {% if application.rsvp is none %}
                             <p>To confirm your attendance at {{ hackathon_name }}, please RSVP using the accept or decline buttons below.</p> <br />
                             <p>RSVP by <b>{{ rsvp_deadline }} (11:59PM EST)</b>, otherwise your spot will be given to other applicants.
                                 Alternatively you can decline the offer. You can change your response at any time before <b>{{ rsvp_deadline }} (11:59PM EST)</b>.
@@ -72,7 +72,7 @@
 
                     {% if not rsvp_passed %}
                         <div style="display: flex; width: auto">
-                            {% if application.rsvp is False or application.rsvp is None %}
+                            {% if application.rsvp is sameas false or application.rsvp is none %}
                             <a
                                 href="{{ url("registration:rsvp", kwargs={"rsvp": "yes"}) }}"
                                 class="btn-small waves-effect waves-light colorBtn"
@@ -81,7 +81,7 @@
                                 Will Attend (Accept)
                             </a>
                             {% endif %}
-                            {% if application.rsvp or application.rsvp is None %}
+                            {% if application.rsvp or application.rsvp is none %}
                             <a
                                 href="{{ url("registration:rsvp", kwargs={"rsvp": "no"})}}"
                                 class="btn-small waves-effect waves-light redBtn"
@@ -93,7 +93,7 @@
 
                     {% elif rsvp_passed and application.rsvp %}
                         <p><b>The RSVP deadline has passed. Thanks for confirming your position at {{ hackathon_name }}! We look forward to seeing you there. Note that you cannot change your RSVP at this time.</b></p>
-                    {% elif rsvp_passed and application.rsvp is False %}
+                    {% elif rsvp_passed and application.rsvp is sameas false %}
                         <p><b>The RSVP deadline has passed. We regret to see that you will not be joining us this year at {{ hackathon_name }}. Unfortunately you cannot change your RSVP at this time.</b></p>
                     {% else %}
                         <p><b>It appears you haven't RSVPed. Unfortunately the RSVP deadline has passed and you cannot change your RSVP at this time.</b></p>

--- a/hackathon_site/event/static/event/styles/scss/_variables.scss
+++ b/hackathon_site/event/static/event/styles/scss/_variables.scss
@@ -5,6 +5,8 @@ $colors: (
     secondary: #ffcb17,
     light: #dad1e9,
     dark: #271648,
+    error: #b00020,
+    success: #0b890b,
 );
 
 $fonts: (

--- a/hackathon_site/event/static/event/styles/scss/styles.scss
+++ b/hackathon_site/event/static/event/styles/scss/styles.scss
@@ -228,6 +228,13 @@ strong {
     color: color(secondary) !important;
 }
 
+.errorText {
+    color: color(error);
+}
+.successText {
+    color: color(success);
+}
+
 .colorBtn {
     font-weight: bold !important;
     text-align: center;
@@ -244,8 +251,8 @@ strong {
     font-weight: bold !important;
     text-align: center;
     text-transform: uppercase;
-    color: #f3c7c7 !important;
-    background-color: #b40000 !important;
+    color: color(white) !important;
+    background-color: color(error) !important;
 
     &:hover {
         background-color: #870000 !important;

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -261,11 +261,10 @@ class DashboardTestCase(SetupUserMixin, TestCase):
 
         response = self.client.get(self.view)
 
-        self.assertContains(response, "Offer Accepted")
+        self.assertContains(response, "Will Attend (Accepted)")
         self.assertContains(
             response, f"You've been accepted into {settings.HACKATHON_NAME}!"
         )
-
         self.assertContains(response, f"{settings.CHAT_ROOM[0]}")
         self.assertContains(response, f"{settings.CHAT_ROOM[1]}")
 
@@ -293,7 +292,7 @@ class DashboardTestCase(SetupUserMixin, TestCase):
 
         response = self.client.get(self.view)
 
-        self.assertContains(response, "Offer Declined")
+        self.assertContains(response, "Cannot Attend (Declined)")
         self.assertContains(
             response, f"You've been accepted into {settings.HACKATHON_NAME}!"
         )

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -266,10 +266,7 @@ class DashboardTestCase(SetupUserMixin, TestCase):
         self.assertContains(response, f"{settings.CHAT_ROOM[0]}")
         self.assertContains(response, f"{settings.CHAT_ROOM[1]}")
 
-        # Buttons for RSVP still appear
-        self.assertContains(
-            response, reverse("registration:rsvp", kwargs={"rsvp": "yes"})
-        )
+        # Button to decline still appears
         self.assertContains(
             response, reverse("registration:rsvp", kwargs={"rsvp": "no"})
         )
@@ -295,12 +292,9 @@ class DashboardTestCase(SetupUserMixin, TestCase):
             response, f"Hope to see you next year at {settings.HACKATHON_NAME}"
         )
 
-        # Buttons for RSVP still appear
+        # Button to accept still appears
         self.assertContains(
             response, reverse("registration:rsvp", kwargs={"rsvp": "yes"})
-        )
-        self.assertContains(
-            response, reverse("registration:rsvp", kwargs={"rsvp": "no"})
         )
 
         # Can't join teams anymore because reviewed

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -266,9 +266,12 @@ class DashboardTestCase(SetupUserMixin, TestCase):
         self.assertContains(response, f"{settings.CHAT_ROOM[0]}")
         self.assertContains(response, f"{settings.CHAT_ROOM[1]}")
 
-        # Button to decline still appears
+        # Button to decline still appears and button to accept is gone
         self.assertContains(
             response, reverse("registration:rsvp", kwargs={"rsvp": "no"})
+        )
+        self.assertNotContains(
+            response, reverse("registration:rsvp", kwargs={"rsvp": "yes"})
         )
 
         # Can't join teams anymore because reviewed
@@ -292,9 +295,12 @@ class DashboardTestCase(SetupUserMixin, TestCase):
             response, f"Hope to see you next year at {settings.HACKATHON_NAME}"
         )
 
-        # Button to accept still appears
+        # Button to accept still appears and button to decline is gone
         self.assertContains(
             response, reverse("registration:rsvp", kwargs={"rsvp": "yes"})
+        )
+        self.assertNotContains(
+            response, reverse("registration:rsvp", kwargs={"rsvp": "no"})
         )
 
         # Can't join teams anymore because reviewed

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -262,9 +262,7 @@ class DashboardTestCase(SetupUserMixin, TestCase):
         response = self.client.get(self.view)
 
         self.assertContains(response, "Will Attend (Accepted)")
-        self.assertContains(
-            response, f"See you at {settings.HACKATHON_NAME}!"
-        )
+        self.assertContains(response, f"See you at {settings.HACKATHON_NAME}!")
         self.assertContains(response, f"{settings.CHAT_ROOM[0]}")
         self.assertContains(response, f"{settings.CHAT_ROOM[1]}")
 

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -263,7 +263,7 @@ class DashboardTestCase(SetupUserMixin, TestCase):
 
         self.assertContains(response, "Will Attend (Accepted)")
         self.assertContains(
-            response, f"You've been accepted into {settings.HACKATHON_NAME}!"
+            response, f"See you at {settings.HACKATHON_NAME}!"
         )
         self.assertContains(response, f"{settings.CHAT_ROOM[0]}")
         self.assertContains(response, f"{settings.CHAT_ROOM[1]}")
@@ -294,7 +294,7 @@ class DashboardTestCase(SetupUserMixin, TestCase):
 
         self.assertContains(response, "Cannot Attend (Declined)")
         self.assertContains(
-            response, f"You've been accepted into {settings.HACKATHON_NAME}!"
+            response, f"Hope to see you next year at {settings.HACKATHON_NAME}"
         )
 
         # Buttons for RSVP still appear

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -143,9 +143,9 @@ class DashboardView(LoginRequiredMixin, FormView):
         ):
             context["status"] = "Rejected"
         elif self.request.user.application.rsvp:
-            context["status"] = "Offer Accepted"
+            context["status"] = "Will Attend (Accepted)"
         elif not self.request.user.application.rsvp:
-            context["status"] = "Offer Declined"
+            context["status"] = "Cannot Attend (Declined)"
         else:
             context["status"] = "Unknown"
 


### PR DESCRIPTION
## Overview

- Some participants did not know if they successfully RSVP'ed for the event after being accepted
- The only part of the page that changed was "Status: `<blah>`" which may have been too small to notice
- 3 things on the dashboard were changed to make things clearer:

1. The `<h4>` header changes depending on the status
          a. Original: Congratulations! You've been accepted into {{ hackathon_name }}!
          b. New when you accept: Thanks for RSVP'ing! See you at {{ hackathon_name }}
          c. New when you decline: Thanks for letting us know. Hope to see you next year at {{ hackathon_name }}
2. The status of accepting/declining the RSVP has been changed to be the same as the text inside the button
         a. Offer Accepted ----> Will Attend (Accepted)
         b. Offer Declined -----> Cannot Attend (Declined)
3. A checkmark or X icon has been added to the status once you accept/decline
4. The RSVP button they click disappears


## Unit Tests Created

- Revised`test_dashboard_rsvp_offer_declined_and_before_rsvp_deadline` and `test_dashboard_rsvp_offer_accepted_and_before_rsvp_deadline` to reflect the rename in status


## Steps to QA

- Make an account and complete the application
- On the admin side, accept the application
- On the dashboard of the applicant, make sure the 4 changes listed in **Overview** are there when you toggle between "Will Attend (Accept)" and "Cannot Attend (Decline)" 

