### PR TITLE
Removed psycopg2 and left psycopg2-binary

### DIFF
--- a/hackathon_site/requirements.txt
+++ b/hackathon_site/requirements.txt
@@ -23,7 +23,6 @@ MarkupSafe==1.1.1
 packaging==20.4
 pathspec==0.8.0
 Pillow==8.1.1
-psycopg2==2.8.5
 psycopg2-binary==2.8.5
 pyparsing==2.4.7
 pytz==2020.1


### PR DESCRIPTION
## Overview

- Resolves #191
- Removes psycopg2 from the requirements.txt file, and leaves only the psycopg2-binary. This seems to solve some issues people were having with building the requirements file.


## Unit Tests Created

- None


## Steps to QA

- Create a new dry virtual environment `python -n testenv python=3.8` and then `pip install -r requirements.txt`  and if no errors then should be good

