### PR TITLE
Updated all instances of strftime date format strings

### DIFF
--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -103,7 +103,7 @@
                     {% elif review.status == "Waitlisted" %}
                         <h4 class="formH2">You've been waitlisted for {{ hackathon_name }}</h4>
                         <p>The {{ hackathon_name }} team has reviewed your application, and have decided not to grant you a guaranteed spot
-                            at {{ hackathon_name }} and to place you in our waitlist. On {{ waitlisted_acceptance_start_time.strftime("%b %d %Y, at %I:%M%p") }}, we will begin allowing
+                            at {{ hackathon_name }} and to place you in our waitlist. On {{ waitlisted_acceptance_start_time.strftime("%B %-d, %Y, at %I:%M%p") }}, we will begin allowing
                             people from the waitlist into the event on a first-come, first-serve basis if there is still room. We offer no
                             guarantee that you will be allowed into the event, regardless of how early you arrive. Please read our 
                             <a class="primaryText hoverLink" href="{{ participant_package_link }}" rel="noopener" target="_blank">participant package</a> for all the info regarding the event if you plan on 

--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -103,7 +103,7 @@
                     {% elif review.status == "Waitlisted" %}
                         <h4 class="formH2">You've been waitlisted for {{ hackathon_name }}</h4>
                         <p>The {{ hackathon_name }} team has reviewed your application, and have decided not to grant you a guaranteed spot
-                            at {{ hackathon_name }} and to place you in our waitlist. On {{ waitlisted_acceptance_start_time.strftime("%B %-d, %Y, at %I:%M%p") }}, we will begin allowing
+                            at {{ hackathon_name }} and to place you in our waitlist. On {{ waitlisted_acceptance_start_time.strftime("%B %-d, %Y, at %-I:%M %p") }}, we will begin allowing
                             people from the waitlist into the event on a first-come, first-serve basis if there is still room. We offer no
                             guarantee that you will be allowed into the event, regardless of how early you arrive. Please read our 
                             <a class="primaryText hoverLink" href="{{ participant_package_link }}" rel="noopener" target="_blank">participant package</a> for all the info regarding the event if you plan on 

--- a/hackathon_site/event/jinja2/event/landing.html
+++ b/hackathon_site/event/jinja2/event/landing.html
@@ -2,9 +2,9 @@
 
 {% block head_extends %}
 <script>
-    const registrationOpenDate = new Date("{{ localtime(registration_open_date).strftime('%b %-d, %Y, %H:%M:%S') }}");
-    const registrationCloseDate = new Date("{{ localtime(registration_close_date).strftime('%b %-d, %Y, %H:%M:%S') }}");
-    const eventStartDate = new Date("{{ localtime(event_start_date).strftime('%b %-d, %Y, %H:%M:%S') }}");
+    const registrationOpenDate = new Date("{{ localtime(registration_open_date).strftime('%B %-d, %Y, %H:%M:%S') }}");
+    const registrationCloseDate = new Date("{{ localtime(registration_close_date).strftime('%B %-d, %Y, %H:%M:%S') }}");
+    const eventStartDate = new Date("{{ localtime(event_start_date).strftime('%B %-d, %Y, %H:%M:%S') }}");
 </script>
 {% endblock %}
 
@@ -32,7 +32,7 @@
                     <h5>Location</h5>
                     <h5>
                         {# Update this logic if your event ends in a different month or year #}
-                        {{ localtime(event_start_date).strftime("%B %d") }}-{{ localtime(event_end_date).strftime("%d, %Y") }}
+                        {{ localtime(event_start_date).strftime("%B %-d") }}-{{ localtime(event_end_date).strftime("%-d, %Y") }}
                     </h5>
                 </div>
                 <div class="row">

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -108,7 +108,7 @@ class DashboardView(LoginRequiredMixin, FormView):
             )
             context["rsvp_deadline"] = (
                 review.decision_sent_date + timedelta(days=settings.RSVP_DAYS)
-            ).strftime("%b %d %Y")
+            ).strftime("%B %-d %Y")
         else:
             context["review"] = None
 

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -108,7 +108,7 @@ class DashboardView(LoginRequiredMixin, FormView):
             )
             context["rsvp_deadline"] = (
                 review.decision_sent_date + timedelta(days=settings.RSVP_DAYS)
-            ).strftime("%B %-d %Y")
+            ).strftime("%B %-d, %Y")
         else:
             context["review"] = None
 

--- a/hackathon_site/review/tests.py
+++ b/hackathon_site/review/tests.py
@@ -219,7 +219,7 @@ class MailerTestCase(SetupUserMixin, TestCase):
 
         rsvp_deadline = (
             datetime.now().date() + timedelta(days=settings.RSVP_DAYS)
-        ).strftime("%b %d %Y")
+        ).strftime("%B %-d %Y")
 
         self.assertIn(link, mail.outbox[0].body)
         self.assertIn(rsvp_deadline, mail.outbox[0].body)

--- a/hackathon_site/review/views.py
+++ b/hackathon_site/review/views.py
@@ -63,7 +63,7 @@ class MailerView(UserPassesTestMixin, FormView):
                     "request": self.request,
                     "rsvp_deadline": (
                         current_date + timedelta(days=settings.RSVP_DAYS)
-                    ).strftime("%b %d %Y"),
+                    ).strftime("%B %-d %Y"),
                 }
 
                 review.application.user.email_user(


### PR DESCRIPTION
## Overview

- Resolves #239
- Changed all instances of strftime to use %B for months (instead of %b) and %-d for days of months (instead of %d)
   - %B formats months as "January" whereas %b formats dates as "Jan"
   - %-d formats days as "2" whereas %d formats dates as "02"
- Used `grep -r "strftime"` to ensure all instances of strftime were updated


## Unit Tests Created

- None
- All tests ran again to ensure nothing broke


## Steps to QA

- Run `grep -r "strftime"` and ensure all strftime instances contain only %B and %-d
- Run the site and look at those instances to make sure they are formatted correctly

