### PR TITLE
Remove hardcoded dashboard dates

### DIFF
--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -103,7 +103,7 @@
                     {% elif review.status == "Waitlisted" %}
                         <h4 class="formH2">You've been waitlisted for {{ hackathon_name }}</h4>
                         <p>The {{ hackathon_name }} team has reviewed your application, and have decided not to grant you a guaranteed spot
-                            at {{ hackathon_name }} and to place you in our waitlist. On {{ waitlisted_acceptance_start_time.strftime("%B %-d, %Y, at %-I:%M%P") }}, we will begin allowing
+                            at {{ hackathon_name }} and to place you in our waitlist. On {{ waitlisted_acceptance_start_time.strftime("%B %-d, %Y, at %-I:%M %p") }}, we will begin allowing
                             people from the waitlist into the event on a first-come, first-serve basis if there is still room. We offer no
                             guarantee that you will be allowed into the event, regardless of how early you arrive. Please read our 
                             <a class="primaryText hoverLink" href="{{ participant_package_link }}" rel="noopener" target="_blank">participant package</a> for all the info regarding the event if you plan on 
@@ -211,7 +211,7 @@
                 <p class="faqAnswer">Please send an email to <a href="mailto:{{ contact_email }}" class="primaryText hoverLink">{{ contact_email }}</a> with your name, email you used to apply, expected arrival time, and reason as to why you’re arriving late and we’ll save your spot for you.</p>
 
                 <p class="faqQuestion">How does the waitlist work the day of?</p>
-                <p class="faqAnswer">The rank on the waitlist is first-come first serve, meaning the sooner you arrive at the event on {{ waitlisted_acceptance_start_time.strftime("%A") }}, the higher your placement on our waitlist. At {{ waitlisted_acceptance_start_time.strftime("%-I:%M%P") }}, if we have any spots remaining, we will be letting waitlisted people in.</p>
+                <p class="faqAnswer">The rank on the waitlist is first-come first serve, meaning the sooner you arrive at the event on {{ waitlisted_acceptance_start_time.strftime("%A") }}, the higher your placement on our waitlist. At {{ waitlisted_acceptance_start_time.strftime("%-I:%M %p") }}, if we have any spots remaining, we will be letting waitlisted people in.</p>
 
                 <p class="faqQuestion">Other questions?</p>
                 <p class="faqAnswer">If you have any questions or concerns, feel free to contact us at <a href="mailto:{{ contact_email }}" class="primaryText hoverLink">{{ contact_email }}</a>.</p>

--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -211,7 +211,7 @@
                 <p class="faqAnswer">Please send an email to <a href="mailto:{{ contact_email }}" class="primaryText hoverLink">{{ contact_email }}</a> with your name, email you used to apply, expected arrival time, and reason as to why you’re arriving late and we’ll save your spot for you.</p>
 
                 <p class="faqQuestion">How does the waitlist work the day of?</p>
-                <p class="faqAnswer">The rank on the waitlist is first-come first serve, meaning the sooner you arrive at the event on Saturday, the higher your placement on our waitlist. At 10AM, if we have any spots remaining, we will be letting waitlisted people in.</p>
+                <p class="faqAnswer">The rank on the waitlist is first-come first serve, meaning the sooner you arrive at the event on {{ event_start_date.strftime("%A") }}, the higher your placement on our waitlist. At {{ event_start_date.strftime("%I%p") }}, if we have any spots remaining, we will be letting waitlisted people in.</p>
 
                 <p class="faqQuestion">Other questions?</p>
                 <p class="faqAnswer">If you have any questions or concerns, feel free to contact us at <a href="mailto:{{ contact_email }}" class="primaryText hoverLink">{{ contact_email }}</a>.</p>

--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -57,11 +57,11 @@
                         {% if not rsvp_passed %}
                             {% if application.rsvp is none %}
                                 <p>To confirm your attendance at {{ hackathon_name }}, please RSVP using the accept or decline buttons below.</p> <br />
-                                <p>RSVP by <b>{{ rsvp_deadline }} (11:59PM EST)</b>, otherwise your spot will be given to other applicants.
-                                    Alternatively you can decline the offer. You can change your response at any time before <b>{{ rsvp_deadline }} (11:59PM EST)</b>.
+                                <p>RSVP by <b>{{ rsvp_deadline }}</b>, otherwise your spot will be given to other applicants.
+                                    Alternatively you can decline the offer. You can change your response at any time before <b>{{ rsvp_deadline }}</b>.
                                 </p> <br />
                             {% else %}
-                                <p>You can change your response at any time before <b>{{ rsvp_deadline }} (11:59PM EST)</b>.</p> <br />
+                                <p>You can change your response at any time before <b>{{ rsvp_deadline }}</b>.</p> <br />
                             {% endif %}
                         {% endif %}
 

--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -103,7 +103,7 @@
                     {% elif review.status == "Waitlisted" %}
                         <h4 class="formH2">You've been waitlisted for {{ hackathon_name }}</h4>
                         <p>The {{ hackathon_name }} team has reviewed your application, and have decided not to grant you a guaranteed spot
-                            at {{ hackathon_name }} and to place you in our waitlist. On {{ waitlisted_acceptance_start_time.strftime("%B %-d, %Y, at %-I:%M %p") }}, we will begin allowing
+                            at {{ hackathon_name }} and to place you in our waitlist. On {{ waitlisted_acceptance_start_time.strftime("%B %-d, %Y, at %-I:%M%P") }}, we will begin allowing
                             people from the waitlist into the event on a first-come, first-serve basis if there is still room. We offer no
                             guarantee that you will be allowed into the event, regardless of how early you arrive. Please read our 
                             <a class="primaryText hoverLink" href="{{ participant_package_link }}" rel="noopener" target="_blank">participant package</a> for all the info regarding the event if you plan on 
@@ -211,7 +211,7 @@
                 <p class="faqAnswer">Please send an email to <a href="mailto:{{ contact_email }}" class="primaryText hoverLink">{{ contact_email }}</a> with your name, email you used to apply, expected arrival time, and reason as to why you’re arriving late and we’ll save your spot for you.</p>
 
                 <p class="faqQuestion">How does the waitlist work the day of?</p>
-                <p class="faqAnswer">The rank on the waitlist is first-come first serve, meaning the sooner you arrive at the event on {{ waitlisted_acceptance_start_time.strftime("%A") }}, the higher your placement on our waitlist. At {{ waitlisted_acceptance_start_time.strftime("%I%p") }}, if we have any spots remaining, we will be letting waitlisted people in.</p>
+                <p class="faqAnswer">The rank on the waitlist is first-come first serve, meaning the sooner you arrive at the event on {{ waitlisted_acceptance_start_time.strftime("%A") }}, the higher your placement on our waitlist. At {{ waitlisted_acceptance_start_time.strftime("%-I:%M%P") }}, if we have any spots remaining, we will be letting waitlisted people in.</p>
 
                 <p class="faqQuestion">Other questions?</p>
                 <p class="faqAnswer">If you have any questions or concerns, feel free to contact us at <a href="mailto:{{ contact_email }}" class="primaryText hoverLink">{{ contact_email }}</a>.</p>

--- a/hackathon_site/event/jinja2/event/dashboard_base.html
+++ b/hackathon_site/event/jinja2/event/dashboard_base.html
@@ -211,7 +211,7 @@
                 <p class="faqAnswer">Please send an email to <a href="mailto:{{ contact_email }}" class="primaryText hoverLink">{{ contact_email }}</a> with your name, email you used to apply, expected arrival time, and reason as to why you’re arriving late and we’ll save your spot for you.</p>
 
                 <p class="faqQuestion">How does the waitlist work the day of?</p>
-                <p class="faqAnswer">The rank on the waitlist is first-come first serve, meaning the sooner you arrive at the event on {{ event_start_date.strftime("%A") }}, the higher your placement on our waitlist. At {{ event_start_date.strftime("%I%p") }}, if we have any spots remaining, we will be letting waitlisted people in.</p>
+                <p class="faqAnswer">The rank on the waitlist is first-come first serve, meaning the sooner you arrive at the event on {{ waitlisted_acceptance_start_time.strftime("%A") }}, the higher your placement on our waitlist. At {{ waitlisted_acceptance_start_time.strftime("%I%p") }}, if we have any spots remaining, we will be letting waitlisted people in.</p>
 
                 <p class="faqQuestion">Other questions?</p>
                 <p class="faqAnswer">If you have any questions or concerns, feel free to contact us at <a href="mailto:{{ contact_email }}" class="primaryText hoverLink">{{ contact_email }}</a>.</p>

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -108,13 +108,13 @@ class DashboardView(LoginRequiredMixin, FormView):
             ] = _now().date() > review.decision_sent_date + timedelta(
                 days=settings.RSVP_DAYS
             )
-            rsvp_timezone = pytz.timezone(str(settings.TZ_INFO))
-            rsvp_datetime = datetime.fromordinal(
-                review.decision_sent_date.toordinal()
-            ) + timedelta(days=settings.RSVP_DAYS, hours=23, minutes=59)
-            context["rsvp_deadline"] = rsvp_timezone.localize(rsvp_datetime).strftime(
-                "%B %-d, %Y, %-I:%M %p %Z"
+            rsvp_deadline = datetime.combine(
+                review.decision_sent_date + timedelta(days=settings.RSVP_DAYS),
+                datetime.max.time(),  # 11:59PM
             )
+            context["rsvp_deadline"] = settings.TZ_INFO.localize(
+                rsvp_deadline
+            ).strftime("%B %-d, %Y, %-I:%M %p %Z")
         else:
             context["review"] = None
 

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timedelta
+
+import pytz
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.shortcuts import redirect
@@ -106,9 +108,13 @@ class DashboardView(LoginRequiredMixin, FormView):
             ] = _now().date() > review.decision_sent_date + timedelta(
                 days=settings.RSVP_DAYS
             )
-            context["rsvp_deadline"] = (
-                review.decision_sent_date + timedelta(days=settings.RSVP_DAYS)
-            ).strftime("%B %-d, %Y")
+            rsvp_timezone = pytz.timezone(str(settings.TZ_INFO))
+            rsvp_datetime = datetime.fromordinal(
+                review.decision_sent_date.toordinal()
+            ) + timedelta(days=settings.RSVP_DAYS, hours=23, minutes=59)
+            context["rsvp_deadline"] = rsvp_timezone.localize(rsvp_datetime).strftime(
+                "%B %-d, %Y, %-I:%M %p %Z"
+            )
         else:
             context["review"] = None
 

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -114,7 +114,7 @@ class DashboardView(LoginRequiredMixin, FormView):
             )
             context["rsvp_deadline"] = settings.TZ_INFO.localize(
                 rsvp_deadline
-            ).strftime("%B %-d, %Y, %-I:%M %p %Z")
+            ).strftime("%B %-d, %Y, %-I:%M%P %Z")
         else:
             context["review"] = None
 

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -113,7 +113,7 @@ class DashboardView(LoginRequiredMixin, FormView):
             )
             context["rsvp_deadline"] = settings.TZ_INFO.localize(
                 rsvp_deadline
-            ).strftime("%B %-d, %Y, %-I:%M%P %Z")
+            ).strftime("%B %-d, %Y, %-I:%M %p %Z")
         else:
             context["review"] = None
 

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -7,7 +7,6 @@ from django.urls import reverse_lazy
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
 from django.conf import settings
-import pytz
 
 from hackathon_site.utils import is_registration_open
 from registration.forms import JoinTeamForm

--- a/hackathon_site/event/views.py
+++ b/hackathon_site/event/views.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 
-import pytz
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.shortcuts import redirect
@@ -8,6 +7,7 @@ from django.urls import reverse_lazy
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
 from django.conf import settings
+import pytz
 
 from hackathon_site.utils import is_registration_open
 from registration.forms import JoinTeamForm


### PR DESCRIPTION
## Overview

- Resolves #211
- Updates dashboard FAQ to use dynamic weekday and start time.
- Updates rsvp_deadline to include time and timezone
    - Note that `event/views.py:111-112` are required to create the timezone using the localize call on `115`
- Changes date to format as `May 11, 2021, 11:59 PM EDT`. Note there was an argument as per `11:59PM vs 11:59 PM` and all upper and lowercase variants thereof - the lowercase variant does not work on macs so we are using the uppercase variant with a space.


## Unit Tests Created

- None


## Steps to QA

- Go into your dashboard and create an application and accept yourself on the admin site. Check the dashboard to make sure the date format is like : `May 11, 2021, 11:59 PM EDT`.
    - Note that EDT or EST appears depending on the date being during daylight savings time or not.
- Also check the FAQ to make sure the day of week and event start time match the settings file.