### PR TITLE
Migrate Admin site CSV downloading from makeuoft-site-2020 PR#30

### DIFF
--- a/hackathon_site/registration/admin.py
+++ b/hackathon_site/registration/admin.py
@@ -1,11 +1,59 @@
+import csv
+import functools
+
 from django.contrib import admin
+from django.http import HttpResponse
+from django.core.exceptions import ObjectDoesNotExist
+
 from registration.models import Application, Team as TeamApplied
+
+
+def rgetattr(obj, attr, *args):
+    """
+    Recursive getattr, allows for nested attributes.
+    For example if you're in the Application class, you can't do getattr for user.first_name
+    But with rgetattr you can.
+    """
+
+    def _getattr(obj, attr):
+        return getattr(obj, attr, *args)
+
+    return functools.reduce(_getattr, [obj] + attr.split("."))
 
 
 class ApplicationInline(admin.TabularInline):
     model = Application
     autocomplete_fields = ("user",)
     extra = 0
+
+
+class ExportCsvMixin:
+    export_fields = []
+
+    def export_as_csv(self, request, queryset):
+        # Setup export_field_names and export_field_attributes arrays
+        export_field_names, export_field_attributes = list(zip(*self.export_fields))
+
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = "attachment; filename={}.csv".format(
+            self.model._meta
+        )
+        writer = csv.writer(response)
+
+        writer.writerow(export_field_names)
+        for obj in queryset:
+            attributes = []
+            for field in export_field_attributes:
+                try:
+                    attributes.append(rgetattr(obj, field))
+                except ObjectDoesNotExist:
+                    attributes.append(None)
+
+            writer.writerow(attributes)
+
+        return response
+
+    export_as_csv.short_description = "Export Selected"
 
 
 @admin.register(TeamApplied)
@@ -24,7 +72,7 @@ class TeamAppliedAdmin(admin.ModelAdmin):
 
 
 @admin.register(Application)
-class ApplicationAdmin(admin.ModelAdmin):
+class ApplicationAdmin(admin.ModelAdmin, ExportCsvMixin):
     autocomplete_fields = ("user", "team")
     list_display = ("get_full_name", "team", "school")
     search_fields = (
@@ -34,6 +82,24 @@ class ApplicationAdmin(admin.ModelAdmin):
         "team__team_code",
     )
     list_filter = ("school",)
+    actions = ["export_as_csv"]
+
+    export_fields = [
+        ("First Name", "user.first_name"),
+        ("Last Name", "user.last_name"),
+        ("Email", "user"),
+        ("Team Code", "team"),
+        ("Birthday", "birthday"),
+        ("Gender", "gender"),
+        ("Ethnicity", "ethnicity"),
+        ("School", "school"),
+        ("Study Level", "study_level"),
+        ("Graduation Year", "graduation_year"),
+        ("Review Status", "review.status"),
+        ("RSVP", "rsvp"),
+        ("Created At", "created_at"),
+        ("Updated At", "updated_at"),
+    ]
 
     def get_full_name(self, obj):
         return f"{obj.user.first_name} {obj.user.last_name}"

--- a/hackathon_site/registration/test_admin.py
+++ b/hackathon_site/registration/test_admin.py
@@ -1,0 +1,62 @@
+import csv
+import io
+
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+
+from hackathon_site.tests import SetupUserMixin
+from registration.admin import ApplicationAdmin
+
+
+class ExportCsvAdminTestCase(SetupUserMixin, TestCase):
+    """
+    Test that CSV exportation in the Registration/Application tab works as expected.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.application_view = reverse("admin:registration_application_changelist")
+        self.export_fields = [field[0] for field in ApplicationAdmin.export_fields]
+
+        self.user.is_staff = True
+        self.user.save()
+
+        self.team1 = self._make_full_registration_team(self_users=False)
+        self.team2 = self._make_full_registration_team(self_users=False)
+
+        self.data = {
+            "action": "export_as_csv",
+            "_selected_action": [i.id for i in self.team1.applications.all()],
+        }
+
+    def test_permission_denied(self):
+        self._login()
+
+        response = self.client.post(self.application_view, self.data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_returns_csv_successfully(self):
+        self.user.is_superuser = True
+        self.user.save()
+        self._login()
+
+        response = self.client.post(self.application_view, self.data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode("utf-8")
+        cvs_reader = csv.reader(io.StringIO(content))
+
+        body = list(cvs_reader)
+        headers = body.pop(0)
+
+        self.assertEqual(headers, self.export_fields)
+        self.assertEqual(len(self.team1.applications.all()), len(body))
+
+        response_emails = [user[2] for user in body]  # Emails at index 2 of CSV
+        expected_emails = [app.user.email for app in self.team1.applications.all()]
+        non_expected_emails = [app.user.email for app in self.team2.applications.all()]
+
+        for email in response_emails:
+            self.assertTrue(email in expected_emails)
+            self.assertFalse(email in non_expected_emails)


### PR DESCRIPTION
## Overview

- Resolves #264
- Migrated [PR#30](https://github.com/ieeeuoft/makeuoft-site-2021/pull/30/) from the makeuoft-site-2020
- Created unit tests for the CSVs to ensure only checked off items are included into the csv
- Note that the `resume_sharing` column was not included since that column is not in the `hackathon-template` models and is unique to the `makeuoft-site-2020` schema.


## Unit Tests Created

- Unit test that checks if a HTTP403 error occurs when necessary permissions aren't acquired.
- Unit test that checks includes 8 applications and requests 4 of them are included in the CSV. Checks that only those 4 are included.


## Steps to QA

- Run the unit test
- Create some applications in the admin site(at least 2-3). Go to the admin site `Registration -> Applications` and check off which applications you want in the CSV. Then click on the dropdown and export to csv. Check to make sure that only the checked off applications were included in the CSV and that the data is correct.

