### PR TITLE
Refactor flexPosition mixin

### DIFF
--- a/hackathon_site/dashboard/frontend/src/App.scss
+++ b/hackathon_site/dashboard/frontend/src/App.scss
@@ -3,15 +3,11 @@
 
 .App {
     background-color: color(backgroundC);
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+    @include flexPosition($jusCon: space-between, $dir: column);
     min-height: 100vh;
     width: 100%;
     &Padding {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
+        @include flexPosition($alIte: center, $dir: column);
         padding: 50px;
         @include responsive(md-down) {
             padding: 25px;

--- a/hackathon_site/dashboard/frontend/src/assets/abstracts/_mixins.scss
+++ b/hackathon_site/dashboard/frontend/src/assets/abstracts/_mixins.scss
@@ -1,7 +1,14 @@
-@mixin flexPosition($jusCon: space-between, $alIte: center) {
+@mixin flexPosition($jusCon: flex-start, $alIte: stretch, $dir: row) {
     display: flex;
-    justify-content: $jusCon;
-    align-items: $alIte;
+    @if $jusCon != flex-start {
+        justify-content: $jusCon;
+    }
+    @if $alIte != stretch {
+        align-items: $alIte;
+    }
+    @if $dir != row {
+        flex-direction: $dir;
+    }
 }
 
 @mixin responsive($breakpoint) {

--- a/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.module.scss
+++ b/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.module.scss
@@ -22,8 +22,7 @@
     }
 
     &Parts {
-        display: flex;
-        flex-direction: column;
+        @include flexPosition($dir: column);
         width: 100%;
         padding-left: 30px;
         padding-top: 10px;

--- a/hackathon_site/dashboard/frontend/src/components/cart/CartSummary/CartSummary.module.scss
+++ b/hackathon_site/dashboard/frontend/src/components/cart/CartSummary/CartSummary.module.scss
@@ -1,6 +1,8 @@
+@import "./../../../assets/abstracts/mixins";
+@import "./../../../assets/abstracts/variables";
+
 .qty {
-    display: flex;
-    justify-content: space-between;
+    @include flexPosition($jusCon: space-between);
     padding: 10px 20px;
 }
 .msg {

--- a/hackathon_site/dashboard/frontend/src/components/dashboard/DashCard/DashCard.module.scss
+++ b/hackathon_site/dashboard/frontend/src/components/dashboard/DashCard/DashCard.module.scss
@@ -1,9 +1,8 @@
+@import "./../../../assets/abstracts/mixins";
 @import "./../../../assets/abstracts/variables";
 
 .items {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+    @include flexPosition($jusCon: space-between, $alIte: center);
     padding-top: 10px;
     padding-bottom: 10px;
     &:hover {

--- a/hackathon_site/dashboard/frontend/src/components/dashboard/ItemTable/ItemTable.module.scss
+++ b/hackathon_site/dashboard/frontend/src/components/dashboard/ItemTable/ItemTable.module.scss
@@ -12,17 +12,14 @@
 }
 
 .title {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-end;
+    @include flexPosition($jusCon: space-between, $alIte: flex-end);
     &Text {
         margin-bottom: 10px;
     }
     &Chip {
         display: flex;
         &Space {
-            display: flex;
-            justify-content: space-between;
+            @include flexPosition($jusCon: space-between);
         }
         &Text {
             min-width: fit-content;

--- a/hackathon_site/dashboard/frontend/src/components/dashboard/SponsorCard/SponsorCard.module.scss
+++ b/hackathon_site/dashboard/frontend/src/components/dashboard/SponsorCard/SponsorCard.module.scss
@@ -4,8 +4,7 @@
 .sponsors {
     height: 100%;
     width: 400px;
-    display: flex;
-    flex-direction: column;
+    @include flexPosition($dir: column);
     &Paper {
         flex-grow: 1;
         padding: 28px 0;

--- a/hackathon_site/dashboard/frontend/src/components/dashboard/TeamCard/TeamCard.module.scss
+++ b/hackathon_site/dashboard/frontend/src/components/dashboard/TeamCard/TeamCard.module.scss
@@ -1,3 +1,4 @@
+@import "./../../../assets/abstracts/mixins";
 @import "./../../../assets/abstracts/variables";
 
 .name {
@@ -5,7 +6,6 @@
 }
 
 .lastRow {
-    display: flex;
-    justify-content: flex-end;
+    @include flexPosition($jusCon: flex-end);
     padding-top: 6px;
 }

--- a/hackathon_site/dashboard/frontend/src/components/general/Header/Header.module.scss
+++ b/hackathon_site/dashboard/frontend/src/components/general/Header/Header.module.scss
@@ -34,8 +34,7 @@
     &Drawer {
         &Top {
             width: 100%;
-            display: flex;
-            justify-content: flex-end;
+            @include flexPosition($jusCon: flex-end);
             background-color: color(light1);
             padding: 8px 15px;
             svg {

--- a/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.module.scss
+++ b/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.module.scss
@@ -32,16 +32,12 @@
     @include responsive(md-down) {
         width: 100%;
         height: 100%;
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
+        @include flexPosition($jusCon: space-between, $dir: column);
         &Btn,
         &Active {
-            height: 50px;
             width: 100%;
-            display: flex;
-            justify-content: left;
-            padding: 0px 120px 0px 15px;
+            @include flexPosition($jusCon: start);
+            padding: 13px 120px 13px 15px;
             border-radius: 0;
             svg {
                 margin-right: 30px;

--- a/hackathon_site/dashboard/frontend/src/components/general/SideSheetRight/SideSheetRight.module.scss
+++ b/hackathon_site/dashboard/frontend/src/components/general/SideSheetRight/SideSheetRight.module.scss
@@ -2,8 +2,7 @@
 @import "./../../../assets/abstracts/variables";
 
 .header {
-    display: flex;
-    align-items: center;
+    @include flexPosition($alIte: center);
     width: 100%;
     background-color: color(light2);
     z-index: 5;

--- a/hackathon_site/dashboard/frontend/src/components/inventory/InventoryFilter/InventoryFilter.module.scss
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/InventoryFilter/InventoryFilter.module.scss
@@ -4,8 +4,7 @@
 .filter {
     width: 100%;
     height: 100%;
-    @include flexPosition;
-    flex-direction: column;
+    @include flexPosition($jusCon: space-between, $alIte: center, $dir: column);
 
     span {
         font-size: 14px !important;
@@ -27,13 +26,13 @@
     }
 
     &Category {
-        @include flexPosition;
+        @include flexPosition($jusCon: space-between, $alIte: center);
         &Chip {
             background-color: color(blueLight);
         }
     }
     &Btns {
-        @include flexPosition;
+        @include flexPosition($jusCon: space-between, $alIte: center);
         position: sticky;
         bottom: 0;
         width: 100%;

--- a/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.module.scss
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.module.scss
@@ -9,8 +9,7 @@
 .productOverview {
     height: 100%;
     width: 100%;
-    @include flexPosition($alIte: flex-start);
-    flex-direction: column;
+    @include flexPosition($jusCon: space-between, $alIte: flex-start, $dir: column);
 
     &Div {
         width: 100%;
@@ -18,8 +17,7 @@
 }
 
 .mainSection {
-    display: flex;
-    justify-content: space-between;
+    @include flexPosition($jusCon: space-between);
     width: 100%;
 
     h6 {

--- a/hackathon_site/dashboard/frontend/src/pages/Dashboard/Dashboard.module.scss
+++ b/hackathon_site/dashboard/frontend/src/pages/Dashboard/Dashboard.module.scss
@@ -13,8 +13,7 @@
             height: 100%;
             min-height: 283px;
             width: 100%;
-            display: flex;
-            flex-direction: column;
+            @include flexPosition($dir: column);
         }
     }
 }

--- a/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.module.scss
+++ b/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.module.scss
@@ -14,9 +14,7 @@
             margin: 10px 0;
 
             &Div {
-                display: flex;
-                align-items: center;
-                justify-content: space-between;
+                @include flexPosition($jusCon: space-between, $alIte: center);
                 width: auto;
             }
 
@@ -30,7 +28,7 @@
             }
 
             &Refresh {
-                @include flexPosition;
+                @include flexPosition($jusCon: space-between, $alIte: center);
             }
 
             @include responsive(sm-down) {
@@ -64,9 +62,7 @@
 }
 
 .Item {
-    display: flex;
-    flex-direction: column;
-    padding-bottom: 10px;
+    @include flexPosition($dir: column);
     cursor: pointer;
 
     &:hover {


### PR DESCRIPTION
## Overview

- Before `flexPosition`'s default values were `justify-content: space-between` and `align-items: center`, the reasoning being that this was the most common configuration of flexbox we used. However, I realized this isn't clear to someone reading the code so I thought it would be better to use `flexPosition` as a short-form way to call flexbox (thereby reducing up to 4 lines of code to just 1).
- Now `flexPosition` will only add properties that are not its default. Also flex-direction was added as a parameter


## Unit Tests Created

N/A


## Steps to QA

- Go through all the changes, view the component's style in console, and confirm it's the same as it was prior, or just trust me :) 

