### PR TITLE
IEEE 17 GET: /api/hardware/orders/

### DIFF
--- a/hackathon_site/hardware/api_urls.py
+++ b/hackathon_site/hardware/api_urls.py
@@ -6,10 +6,6 @@ app_name = "hardware"
 
 urlpatterns = [
     path("hardware/", views.HardwareListView.as_view(), name="hardware-list",),
-    path(
-        "hardware/orders/",
-        views.HardwareOrderListView.as_view(),
-        name="hardware-order-list",
-    ),
+    path("orders/", views.HardwareOrderListView.as_view(), name="hardware-order-list",),
     path("categories/", views.CategoryListView.as_view(), name="category-list"),
 ]

--- a/hackathon_site/hardware/api_urls.py
+++ b/hackathon_site/hardware/api_urls.py
@@ -6,6 +6,6 @@ app_name = "hardware"
 
 urlpatterns = [
     path("hardware/", views.HardwareListView.as_view(), name="hardware-list",),
-    path("orders/", views.HardwareOrderListView.as_view(), name="hardware-order-list",),
+    path("orders/", views.HardwareOrderListView.as_view(), name="order-list",),
     path("categories/", views.CategoryListView.as_view(), name="category-list"),
 ]

--- a/hackathon_site/hardware/api_urls.py
+++ b/hackathon_site/hardware/api_urls.py
@@ -6,5 +6,10 @@ app_name = "hardware"
 
 urlpatterns = [
     path("hardware/", views.HardwareListView.as_view(), name="hardware-list",),
+    path(
+        "hardware/orders/",
+        views.HardwareOrderListView.as_view(),
+        name="hardware-order-list",
+    ),
     path("categories/", views.CategoryListView.as_view(), name="category-list"),
 ]

--- a/hackathon_site/hardware/api_urls.py
+++ b/hackathon_site/hardware/api_urls.py
@@ -6,6 +6,6 @@ app_name = "hardware"
 
 urlpatterns = [
     path("hardware/", views.HardwareListView.as_view(), name="hardware-list",),
-    path("orders/", views.HardwareOrderListView.as_view(), name="order-list",),
+    path("orders/", views.OrderListView.as_view(), name="order-list",),
     path("categories/", views.CategoryListView.as_view(), name="category-list"),
 ]

--- a/hackathon_site/hardware/models.py
+++ b/hackathon_site/hardware/models.py
@@ -71,7 +71,7 @@ class Order(models.Model):
     updated_at = models.DateTimeField(auto_now=True, null=False)
 
     def __str__(self):
-        return self.id
+        return f"{self.id}"
 
 
 class Incident(models.Model):
@@ -94,4 +94,4 @@ class Incident(models.Model):
     updated_at = models.DateTimeField(auto_now=True, null=False)
 
     def __str__(self):
-        return self.id
+        return f"{self.id}"

--- a/hackathon_site/hardware/serializers.py
+++ b/hackathon_site/hardware/serializers.py
@@ -46,7 +46,7 @@ class CategorySerializer(serializers.ModelSerializer):
         return Hardware.objects.filter(categories__id=obj.id).count()
 
 
-class HardwareOrderSerializer(serializers.ModelSerializer):
+class OrderSerializer(serializers.ModelSerializer):
     hardware_set = HardwareSerializer(many=True, read_only=True)
 
     class Meta:

--- a/hackathon_site/hardware/serializers.py
+++ b/hackathon_site/hardware/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from hardware.models import Hardware, Category, OrderItem
+from hardware.models import Hardware, Category, OrderItem, Order
 
 
 class HardwareSerializer(serializers.ModelSerializer):
@@ -44,3 +44,11 @@ class CategorySerializer(serializers.ModelSerializer):
     @staticmethod
     def get_unique_hardware_count(obj: Category):
         return Hardware.objects.filter(categories__id=obj.id).count()
+
+
+class HardwareOrderSerializer(serializers.ModelSerializer):
+    hardware_set = HardwareSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Order
+        fields = "__all__"

--- a/hackathon_site/hardware/serializers.py
+++ b/hackathon_site/hardware/serializers.py
@@ -51,4 +51,4 @@ class HardwareOrderSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Order
-        fields = "__all__"
+        fields = ("id", "hardware_set", "team", "status", "created_at", "updated_at")

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -83,7 +83,7 @@ class CategoryListViewTestCase(SetupUserMixin, APITestCase):
         self.assertEqual(expected_response, data["results"][0])
 
 
-class HardwareOrderListViewTestCase(SetupUserMixin, APITestCase):
+class OrderListViewTestCase(SetupUserMixin, APITestCase):
     def setUp(self):
         super().setUp()
         self.team = Team.objects.create()

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -7,7 +7,7 @@ from hardware.models import Hardware, Category, Order, OrderItem
 from hardware.serializers import (
     HardwareSerializer,
     CategorySerializer,
-    HardwareOrderSerializer,
+    OrderSerializer,
 )
 from hackathon_site.tests import SetupUserMixin
 
@@ -134,7 +134,7 @@ class HardwareOrderListViewTestCase(SetupUserMixin, APITestCase):
 
         queryset = Order.objects.all()
         # need to provide a request in the serializer context to produce absolute url for image field
-        expected_response = HardwareOrderSerializer(
+        expected_response = OrderSerializer(
             queryset, many=True, context={"request": response.wsgi_request}
         ).data
         data = response.json()

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -128,11 +128,14 @@ class HardwareOrderListViewTestCase(SetupUserMixin, APITestCase):
 
     def test_hardware_get_success(self):
         self._login()
-        queryset = Order.objects.all()
-        expected_response = HardwareOrderSerializer(queryset, many=True).data
 
         response = self.client.get(self.view)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        queryset = Order.objects.all()
+        expected_response = HardwareOrderSerializer(
+            queryset, many=True, context={"request": response.wsgi_request}
+        ).data
         data = response.json()
 
         self.assertEqual(expected_response, data["results"])

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -1,10 +1,14 @@
 from rest_framework.test import APITestCase
-from django.conf import settings
 from django.urls import reverse
 from rest_framework import status
 
-from hardware.models import Hardware, Category
-from hardware.serializers import HardwareSerializer, CategorySerializer
+from event.models import Team
+from hardware.models import Hardware, Category, Order, OrderItem
+from hardware.serializers import (
+    HardwareSerializer,
+    CategorySerializer,
+    HardwareOrderSerializer,
+)
 from hackathon_site.tests import SetupUserMixin
 
 
@@ -77,3 +81,58 @@ class CategoryListViewTestCase(SetupUserMixin, APITestCase):
         data = response.json()
 
         self.assertEqual(expected_response, data["results"][0])
+
+
+class HardwareOrderListViewTestCase(SetupUserMixin, APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.team = Team.objects.create()
+        self.order = Order.objects.create(status="Cart", team=self.team)
+        self.hardware = Hardware.objects.create(
+            name="name",
+            model_number="model",
+            manufacturer="manufacturer",
+            datasheet="/datasheet/location/",
+            notes="notes",
+            quantity_available=4,
+            max_per_team=1,
+            picture="/picture/location",
+        )
+        self.other_hardware = Hardware.objects.create(
+            name="other",
+            model_number="otherModel",
+            manufacturer="otherManufacturer",
+            datasheet="/datasheet/location/other",
+            quantity_available=10,
+            max_per_team=10,
+            picture="/picture/location/other",
+        )
+        OrderItem.objects.create(
+            order=self.order, hardware=self.hardware,
+        )
+        OrderItem.objects.create(
+            order=self.order, hardware=self.other_hardware,
+        )
+        self.order_2 = Order.objects.create(status="Submitted", team=self.team)
+        OrderItem.objects.create(
+            order=self.order_2, hardware=self.hardware,
+        )
+        OrderItem.objects.create(
+            order=self.order_2, hardware=self.other_hardware,
+        )
+        self.view = reverse("api:hardware:order-list")
+
+    def test_user_not_logged_in(self):
+        response = self.client.get(self.view)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_hardware_get_success(self):
+        self._login()
+        queryset = Order.objects.all()
+        expected_response = HardwareOrderSerializer(queryset, many=True).data
+
+        response = self.client.get(self.view)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(expected_response, data["results"])

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -133,6 +133,7 @@ class HardwareOrderListViewTestCase(SetupUserMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         queryset = Order.objects.all()
+        # need to provide a request in the serializer context to produce absolute url for image field
         expected_response = HardwareOrderSerializer(
             queryset, many=True, context={"request": response.wsgi_request}
         ).data

--- a/hackathon_site/hardware/tests.py
+++ b/hackathon_site/hardware/tests.py
@@ -1,8 +1,13 @@
 from django.test import TestCase
+from rest_framework import serializers
 
 from hardware.models import Hardware, Category, Order, OrderItem
 from event.models import Team
-from hardware.serializers import HardwareSerializer, CategorySerializer
+from hardware.serializers import (
+    HardwareSerializer,
+    CategorySerializer,
+    HardwareOrderSerializer,
+)
 
 
 class HardwareSerializerTestCase(TestCase):
@@ -118,3 +123,69 @@ class CategorySerializerTestCase(TestCase):
             "unique_hardware_count": 1,
         }
         self.assertEqual(expected_response, data)
+
+
+class HardwareOrderSerializerTestCase(TestCase):
+    def setUp(self):
+        self.team = Team.objects.create()
+        self.hardware = Hardware.objects.create(
+            name="name",
+            model_number="model",
+            manufacturer="manufacturer",
+            datasheet="/datasheet/location/",
+            quantity_available=4,
+            max_per_team=1,
+            picture="/picture/location",
+        )
+        self.other_hardware = Hardware.objects.create(
+            name="other",
+            model_number="otherModel",
+            manufacturer="otherManufacturer",
+            datasheet="/datasheet/location/other/",
+            quantity_available=10,
+            max_per_team=10,
+            picture="/picture/location/other/",
+        )
+
+    def test_empty_order(self):
+        order = Order.objects.create(status="Cart", team=self.team)
+        order_serializer = HardwareOrderSerializer(order).data
+        expected_response = {
+            "id": 1,
+            "team": self.team.id,
+            "status": "Cart",
+            "hardware_set": [],
+            "created_at": serializers.DateTimeField().to_representation(
+                order.created_at
+            ),
+            "updated_at": serializers.DateTimeField().to_representation(
+                order.updated_at
+            ),
+        }
+        self.assertEqual(order_serializer, expected_response)
+
+    def test_hardware_set(self):
+        order = Order.objects.create(status="Cart", team=self.team)
+        OrderItem.objects.create(
+            order=order, hardware=self.hardware, part_returned_health="Healthy"
+        )
+        OrderItem.objects.create(
+            order=order, hardware=self.other_hardware,
+        )
+        order_serializer = HardwareOrderSerializer(order).data
+        expected_response = {
+            "id": 1,
+            "team": self.team.id,
+            "status": "Cart",
+            "hardware_set": [
+                HardwareSerializer(self.hardware).data,
+                HardwareSerializer(self.other_hardware).data,
+            ],
+            "created_at": serializers.DateTimeField().to_representation(
+                order.created_at
+            ),
+            "updated_at": serializers.DateTimeField().to_representation(
+                order.updated_at
+            ),
+        }
+        self.assertEqual(order_serializer, expected_response)

--- a/hackathon_site/hardware/tests.py
+++ b/hackathon_site/hardware/tests.py
@@ -6,7 +6,7 @@ from event.models import Team
 from hardware.serializers import (
     HardwareSerializer,
     CategorySerializer,
-    HardwareOrderSerializer,
+    OrderSerializer,
 )
 
 
@@ -125,7 +125,7 @@ class CategorySerializerTestCase(TestCase):
         self.assertEqual(expected_response, data)
 
 
-class HardwareOrderSerializerTestCase(TestCase):
+class OrderSerializerTestCase(TestCase):
     def setUp(self):
         self.team = Team.objects.create()
         self.hardware = Hardware.objects.create(
@@ -149,7 +149,7 @@ class HardwareOrderSerializerTestCase(TestCase):
 
     def test_empty_order(self):
         order = Order.objects.create(status="Cart", team=self.team)
-        order_serializer = HardwareOrderSerializer(order).data
+        order_serializer = OrderSerializer(order).data
         expected_response = {
             "id": 1,
             "team": self.team.id,
@@ -172,7 +172,7 @@ class HardwareOrderSerializerTestCase(TestCase):
         OrderItem.objects.create(
             order=order, hardware=self.other_hardware,
         )
-        order_serializer = HardwareOrderSerializer(order).data
+        order_serializer = OrderSerializer(order).data
         expected_response = {
             "id": 1,
             "team": self.team.id,

--- a/hackathon_site/hardware/views.py
+++ b/hackathon_site/hardware/views.py
@@ -23,7 +23,7 @@ class CategoryListView(mixins.ListModelMixin, generics.GenericAPIView):
         return self.list(request, *args, **kwargs)
 
 
-class HardwareOrderListView(mixins.ListModelMixin, generics.GenericAPIView):
+class OrderListView(mixins.ListModelMixin, generics.GenericAPIView):
     queryset = Order.objects.all()
     serializer_class = OrderSerializer
 

--- a/hackathon_site/hardware/views.py
+++ b/hackathon_site/hardware/views.py
@@ -3,7 +3,7 @@ from rest_framework import generics, mixins
 from hardware.serializers import (
     HardwareSerializer,
     CategorySerializer,
-    HardwareOrderSerializer,
+    OrderSerializer,
 )
 
 
@@ -25,7 +25,7 @@ class CategoryListView(mixins.ListModelMixin, generics.GenericAPIView):
 
 class HardwareOrderListView(mixins.ListModelMixin, generics.GenericAPIView):
     queryset = Order.objects.all()
-    serializer_class = HardwareOrderSerializer
+    serializer_class = OrderSerializer
 
     def get(self, request, *args, **kwargs):
         return self.list(request, *args, **kwargs)

--- a/hackathon_site/hardware/views.py
+++ b/hackathon_site/hardware/views.py
@@ -1,6 +1,10 @@
-from hardware.models import Hardware, Category
+from hardware.models import Hardware, Category, Order
 from rest_framework import generics, mixins
-from hardware.serializers import HardwareSerializer, CategorySerializer
+from hardware.serializers import (
+    HardwareSerializer,
+    CategorySerializer,
+    HardwareOrderSerializer,
+)
 
 
 class HardwareListView(mixins.ListModelMixin, generics.GenericAPIView):
@@ -14,6 +18,14 @@ class HardwareListView(mixins.ListModelMixin, generics.GenericAPIView):
 class CategoryListView(mixins.ListModelMixin, generics.GenericAPIView):
     queryset = Category.objects.all()
     serializer_class = CategorySerializer
+
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
+
+
+class HardwareOrderListView(mixins.ListModelMixin, generics.GenericAPIView):
+    queryset = Order.objects.all()
+    serializer_class = HardwareOrderSerializer
 
     def get(self, request, *args, **kwargs):
         return self.list(request, *args, **kwargs)


### PR DESCRIPTION
## Overview

- Resolves IEEE-17
- implement GET: /api/hardware/orders/
- Add serializer for Hardware Order model
- Add list view for GET requests
- Add url for api endpoint
- Add test case for serializer and GET view


## Unit Tests Created

- Serializer test to test empty order and order with 2 hardware
- GET api test for authentication and 2 orders with 2 hardware each


## Steps to QA

- No migration needed. Just run the test cases.

