### PR TITLE
IEEE-5 Category API Updates

### DIFF
--- a/hackathon_site/hardware/serializers.py
+++ b/hackathon_site/hardware/serializers.py
@@ -36,7 +36,6 @@ class CategorySerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_unique_hardware_count(obj: Category) -> int:
-        # return Hardware.objects.filter(categories__id=obj.id).count()
         return obj.hardware_set.annotate(Count("id", distinct=True)).count()
 
 

--- a/hackathon_site/hardware/serializers.py
+++ b/hackathon_site/hardware/serializers.py
@@ -35,7 +35,7 @@ class CategorySerializer(serializers.ModelSerializer):
         fields = ("id", "name", "max_per_team", "unique_hardware_count")
 
     @staticmethod
-    def get_unique_hardware_count(obj: Category):
+    def get_unique_hardware_count(obj: Category) -> int:
         #return Hardware.objects.filter(categories__id=obj.id).count()
         return obj.hardware_set.count()
 

--- a/hackathon_site/hardware/serializers.py
+++ b/hackathon_site/hardware/serializers.py
@@ -37,7 +37,7 @@ class CategorySerializer(serializers.ModelSerializer):
     @staticmethod
     def get_unique_hardware_count(obj: Category) -> int:
         # return Hardware.objects.filter(categories__id=obj.id).count()
-        return obj.hardware_set.annotate(Count("id",distinct=True)).count()
+        return obj.hardware_set.annotate(Count("id", distinct=True)).count()
 
 
 class OrderListSerializer(serializers.ModelSerializer):

--- a/hackathon_site/hardware/serializers.py
+++ b/hackathon_site/hardware/serializers.py
@@ -36,7 +36,7 @@ class CategorySerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_unique_hardware_count(obj: Category) -> int:
-        #return Hardware.objects.filter(categories__id=obj.id).count()
+        # return Hardware.objects.filter(categories__id=obj.id).count()
         return obj.hardware_set.count()
 
 

--- a/hackathon_site/hardware/serializers.py
+++ b/hackathon_site/hardware/serializers.py
@@ -36,7 +36,8 @@ class CategorySerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_unique_hardware_count(obj: Category):
-        return Hardware.objects.filter(categories__id=obj.id).count()
+        #return Hardware.objects.filter(categories__id=obj.id).count()
+        return obj.hardware_set.count()
 
 
 class OrderListSerializer(serializers.ModelSerializer):

--- a/hackathon_site/hardware/serializers.py
+++ b/hackathon_site/hardware/serializers.py
@@ -37,7 +37,7 @@ class CategorySerializer(serializers.ModelSerializer):
     @staticmethod
     def get_unique_hardware_count(obj: Category) -> int:
         # return Hardware.objects.filter(categories__id=obj.id).count()
-        return obj.hardware_set.count(distinct=True)
+        return obj.hardware_set.annotate(Count("id",distinct=True)).count()
 
 
 class OrderListSerializer(serializers.ModelSerializer):

--- a/hackathon_site/hardware/serializers.py
+++ b/hackathon_site/hardware/serializers.py
@@ -37,7 +37,7 @@ class CategorySerializer(serializers.ModelSerializer):
     @staticmethod
     def get_unique_hardware_count(obj: Category) -> int:
         # return Hardware.objects.filter(categories__id=obj.id).count()
-        return obj.hardware_set.count()
+        return obj.hardware_set.count(distinct=True)
 
 
 class OrderListSerializer(serializers.ModelSerializer):

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -139,12 +139,12 @@ class CategoryListViewTestCase(SetupUserMixin, APITestCase):
     def test_hardware_quantity_success(self):
         self._login()
 
-        self.category = Category.objects.create(name="Microcontrollers", max_per_team=4)
-        self.hardware1 = Hardware.objects.create(name="Arduino", quantity_available=2)
-        self.hardware2 = Hardware.objects.create(name="ESP32", quantity_available=3)
+        category2 = Category.objects.create(name="Microcontrollers", max_per_team=4)
+        hardware1 = Hardware.objects.create(name="Arduino", quantity_available=2)
+        hardware2 = Hardware.objects.create(name="ESP32", quantity_available=3)
 
-        self.hardware1.categories.add(self.category)
-        self.hardware2.categories.add(self.category)
+        hardware1.categories.add(category2)
+        hardware2.categories.add(category2)
 
         expected_response = {
             "count": 2,

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -170,9 +170,10 @@ class CategoryListViewTestCase(SetupUserMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
 
-
         expected_unique_hardware_counts = [0, 2]
-        actual_unique_hardware_counts = [result["unique_hardware_count"] for result in data["results"]]
+        actual_unique_hardware_counts = [
+            result["unique_hardware_count"] for result in data["results"]
+        ]
 
         print(data)
         self.assertEqual(expected_unique_hardware_counts, actual_unique_hardware_counts)

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -147,8 +147,6 @@ class CategoryListViewTestCase(SetupUserMixin, APITestCase):
         hardware1.categories.add(self.category)
         hardware2.categories.add(category2)
 
-
-
         response = self.client.get(self.view)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -135,19 +135,36 @@ class CategoryListViewTestCase(SetupUserMixin, APITestCase):
         data = response.json()
 
         self.assertEqual(expected_response, data["results"][0])
-    
+
     def test_hardware_quantity_success(self):
         self._login()
 
         self.category = Category.objects.create(name="Microcontrollers", max_per_team=4)
-        self.hardware1 = Hardware.objects.create(name="Arduino",quantity_available=2)
-        self.hardware2 = Hardware.objects.create(name="ESP32",quantity_available=3)
-
+        self.hardware1 = Hardware.objects.create(name="Arduino", quantity_available=2)
+        self.hardware2 = Hardware.objects.create(name="ESP32", quantity_available=3)
 
         self.hardware1.categories.add(self.category)
         self.hardware2.categories.add(self.category)
 
-        expected_response = {'count': 2, 'next': None, 'previous': None, 'results': [{'id': 1, 'name': 'category', 'max_per_team': 4, 'unique_hardware_count': 0}, {'id': 2, 'name': 'Microcontrollers', 'max_per_team': 4, 'unique_hardware_count': 2}]}
+        expected_response = {
+            "count": 2,
+            "next": None,
+            "previous": None,
+            "results": [
+                {
+                    "id": 1,
+                    "name": "category",
+                    "max_per_team": 4,
+                    "unique_hardware_count": 0,
+                },
+                {
+                    "id": 2,
+                    "name": "Microcontrollers",
+                    "max_per_team": 4,
+                    "unique_hardware_count": 2,
+                },
+            ],
+        }
 
         response = self.client.get(self.view)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -169,7 +169,13 @@ class CategoryListViewTestCase(SetupUserMixin, APITestCase):
         response = self.client.get(self.view)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
-        self.assertEqual(expected_response, data)
+
+
+        expected_unique_hardware_counts = [0, 2]
+        actual_unique_hardware_counts = [result["unique_hardware_count"] for result in data["results"]]
+
+        print(data)
+        self.assertEqual(expected_unique_hardware_counts, actual_unique_hardware_counts)
 
 
 class OrderListViewGetTestCase(SetupUserMixin, APITestCase):

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -156,7 +156,6 @@ class CategoryListViewTestCase(SetupUserMixin, APITestCase):
             result["unique_hardware_count"] for result in data["results"]
         ]
 
-        print(data)
         self.assertEqual(expected_unique_hardware_counts, actual_unique_hardware_counts)
 
 

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -140,16 +140,20 @@ class CategoryListViewTestCase(SetupUserMixin, APITestCase):
         self._login()
 
         self.category = Category.objects.create(name="Microcontrollers", max_per_team=4)
-        self.hardware = Hardware.objects.create(name="Arduino",quantity_available=2,categories=[2])
-        self.hardware = Hardware.objects.create(name="ESP32",quantity_available=3,categories=[2])
-        response = self.client.generics(self.view)
+        self.hardware1 = Hardware.objects.create(name="Arduino",quantity_available=2)
+        self.hardware2 = Hardware.objects.create(name="ESP32",quantity_available=3)
 
-        expected_response = {
-            "id": 2,
-            "name": "Microcontrollers",
-            "max_per_team": 4,
-            "unique_hardware_count": 2,
-        }
+
+        self.hardware1.categories.add(self.category)
+        self.hardware2.categories.add(self.category)
+
+        expected_response = {'count': 2, 'next': None, 'previous': None, 'results': [{'id': 1, 'name': 'category', 'max_per_team': 4, 'unique_hardware_count': 0}, {'id': 2, 'name': 'Microcontrollers', 'max_per_team': 4, 'unique_hardware_count': 2}]}
+
+        response = self.client.get(self.view)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(expected_response, data)
+
 
 class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
     def setUp(self):

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -153,7 +153,7 @@ class CategoryListViewTestCase(SetupUserMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
 
-        expected_unique_hardware_counts = [0, 2]
+        expected_unique_hardware_counts = [1, 2]
         actual_unique_hardware_counts = [
             result["unique_hardware_count"] for result in data["results"]
         ]

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -49,10 +49,10 @@ class HardwareListViewTestCase(SetupUserMixin, APITestCase):
         }
 
         response = self.client.get(self.view)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.json()
-
-        self.assertEqual(expected_response, data["results"][0])
+        # self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # data = response.json()
+        #
+        # self.assertEqual(expected_response, data["results"][0])
 
 
 class HardwareDetailViewTestCase(SetupUserMixin, APITestCase):

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -144,27 +144,10 @@ class CategoryListViewTestCase(SetupUserMixin, APITestCase):
         hardware2 = Hardware.objects.create(name="ESP32", quantity_available=3)
 
         hardware1.categories.add(category2)
+        hardware1.categories.add(self.category)
         hardware2.categories.add(category2)
 
-        expected_response = {
-            "count": 2,
-            "next": None,
-            "previous": None,
-            "results": [
-                {
-                    "id": 1,
-                    "name": "category",
-                    "max_per_team": 4,
-                    "unique_hardware_count": 0,
-                },
-                {
-                    "id": 2,
-                    "name": "Microcontrollers",
-                    "max_per_team": 4,
-                    "unique_hardware_count": 2,
-                },
-            ],
-        }
+
 
         response = self.client.get(self.view)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -49,10 +49,10 @@ class HardwareListViewTestCase(SetupUserMixin, APITestCase):
         }
 
         response = self.client.get(self.view)
-        # self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # data = response.json()
-        #
-        # self.assertEqual(expected_response, data["results"][0])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(expected_response, data["results"][0])
 
 
 class HardwareDetailViewTestCase(SetupUserMixin, APITestCase):

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -135,7 +135,21 @@ class CategoryListViewTestCase(SetupUserMixin, APITestCase):
         data = response.json()
 
         self.assertEqual(expected_response, data["results"][0])
+    
+    def test_hardware_quantity_success(self):
+        self._login()
 
+        self.category = Category.objects.create(name="Microcontrollers", max_per_team=4)
+        self.hardware = Hardware.objects.create(name="Arduino",quantity_available=2,categories=[2])
+        self.hardware = Hardware.objects.create(name="ESP32",quantity_available=3,categories=[2])
+        response = self.client.generics(self.view)
+
+        expected_response = {
+            "id": 2,
+            "name": "Microcontrollers",
+            "max_per_team": 4,
+            "unique_hardware_count": 2,
+        }
 
 class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
     def setUp(self):

--- a/hackathon_site/hardware/views.py
+++ b/hackathon_site/hardware/views.py
@@ -35,7 +35,7 @@ class HardwareDetailView(mixins.RetrieveModelMixin, generics.GenericAPIView):
 
 
 class CategoryListView(mixins.ListModelMixin, generics.GenericAPIView):
-    queryset = Category.objects.all().select_related("hardware")
+    queryset = Category.objects.all()
     serializer_class = CategorySerializer
 
     def get(self, request, *args, **kwargs):

--- a/hackathon_site/hardware/views.py
+++ b/hackathon_site/hardware/views.py
@@ -35,7 +35,7 @@ class HardwareDetailView(mixins.RetrieveModelMixin, generics.GenericAPIView):
 
 
 class CategoryListView(mixins.ListModelMixin, generics.GenericAPIView):
-    queryset = Category.objects.all()
+    queryset = Category.objects.all().selected_related("hardware")
     serializer_class = CategorySerializer
 
     def get(self, request, *args, **kwargs):

--- a/hackathon_site/hardware/views.py
+++ b/hackathon_site/hardware/views.py
@@ -35,7 +35,7 @@ class HardwareDetailView(mixins.RetrieveModelMixin, generics.GenericAPIView):
 
 
 class CategoryListView(mixins.ListModelMixin, generics.GenericAPIView):
-    queryset = Category.objects.all()
+    queryset = Category.objects.all().prefetch_related("hardware_set")
     serializer_class = CategorySerializer
 
     def get(self, request, *args, **kwargs):

--- a/hackathon_site/hardware/views.py
+++ b/hackathon_site/hardware/views.py
@@ -35,7 +35,7 @@ class HardwareDetailView(mixins.RetrieveModelMixin, generics.GenericAPIView):
 
 
 class CategoryListView(mixins.ListModelMixin, generics.GenericAPIView):
-    queryset = Category.objects.all().selected_related("hardware")
+    queryset = Category.objects.all().select_related("hardware")
     serializer_class = CategorySerializer
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
## Overview

- Add a few more unit tests around the unique object count
- Look at the debug toolbar stats, may need to select_related(hardware) in the view
- Type annotate the serializer methods to help out swagger


## Unit Tests Created

Serializer tests for the category serializer are here: https://github.com/ieeeuoft/hackathon-template/blob/develop/hackathon_site/hardware/test_api.py#L112 

The unique_hardware_count field just returns how many types of hardware are in that category. Make a test like this perhaps:

Add a category with name “Microcontrollers”

Add a hardware with name “Arduino”, quantity available 2

Add another hardware with name “ESP32”, quantity available 3

Add both hardware to the microcontrollers category

Test that unique_hardware_count should return 2 (not 5)



