### PR TITLE
Add typescript check stage to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,8 @@ name: CI/CD
 
 on:
   pull_request_target:
-    branches: '**'
+    branches:
+      - '**'
 
 jobs:
   backend-checks:
@@ -73,5 +74,7 @@ jobs:
         run: yarn install
       - name: Formatting check
         run: yarn prettier --check 'src/**/*.(js|ts|tsx|scss)'
+      - name: Typescript check
+        run: yarn run tsc
       - name: Tests
         run: yarn test --watchAll=false

--- a/hackathon_site/dashboard/frontend/yarn.lock
+++ b/hackathon_site/dashboard/frontend/yarn.lock
@@ -8120,18 +8120,6 @@ memory-fs@^0.5.0:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-<<<<<<< HEAD
-=======
-merge-deep@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/merge-deep/-/merge-deep-3.0.3.tgz#1a2b2ae926da8b2ae93a0ac15d90cd1922766003"
-  integrity sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==
-  dependencies:
-    arr-union "^3.1.0"
-    clone-deep "^0.2.4"
-    kind-of "^3.0.2"
-
->>>>>>> develop
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"


### PR DESCRIPTION
## Overview

- Adds a check that runs `yarn run tsc` on the dashboard, to make sure typescript is valid
- Fixes a formatting error in the branches spec that technically still worked, but wasn't valid by the schema


## Steps to QA

- Run it locally to confirm it is a valid command
