### PR TITLE
Connect Logout Button

### DIFF
--- a/hackathon_site/dashboard/frontend/src/api/api.js
+++ b/hackathon_site/dashboard/frontend/src/api/api.js
@@ -26,19 +26,19 @@ export const cleanURI = (uri) => {
     return uri;
 };
 
-const config = {
+const makeConfig = () => ({
     headers: {
         "X-CSRFToken": getCsrfToken(),
     },
     withCredentials: true,
-};
+});
 
 export const get = (uri) => {
     uri = cleanURI(uri);
-    return axios.get(`${SERVER_URL}/${uri}`, config);
+    return axios.get(`${SERVER_URL}/${uri}`, makeConfig());
 };
 
 export const post = (uri, data) => {
     uri = cleanURI(uri);
-    return axios.post(`${SERVER_URL}/${uri}`, data, config);
+    return axios.post(`${SERVER_URL}/${uri}`, data, makeConfig());
 };

--- a/hackathon_site/dashboard/frontend/src/api/api.js
+++ b/hackathon_site/dashboard/frontend/src/api/api.js
@@ -22,7 +22,7 @@ export const getCsrfToken = () => {
 
 export const cleanURI = (uri) => {
     uri = uri.replace(/^\//, ""); // Remove leading slashes
-    uri = uri.endsWith("/") ? uri : (uri + "/");
+    uri = uri.endsWith("/") ? uri : uri + "/";
     return uri;
 };
 

--- a/hackathon_site/dashboard/frontend/src/api/api.js
+++ b/hackathon_site/dashboard/frontend/src/api/api.js
@@ -22,7 +22,7 @@ export const getCsrfToken = () => {
 
 export const cleanURI = (uri) => {
     uri = uri.replace(/^\//, ""); // Remove leading slashes
-    uri = uri.endsWith("/") ? uri : (uri = "/");
+    uri = uri.endsWith("/") ? uri : (uri + "/");
     return uri;
 };
 

--- a/hackathon_site/dashboard/frontend/src/api/api.js
+++ b/hackathon_site/dashboard/frontend/src/api/api.js
@@ -13,7 +13,7 @@ export const getCsrfToken = () => {
         for (let i = 0; i < cookies.length; i++) {
             const cookie = cookies[i].trim();
             if (cookie.trim().startsWith("csrftoken=")) {
-                return decodeURIComponent(cookie.substr(11));
+                return decodeURIComponent(cookie.substr(10));
             }
         }
     }

--- a/hackathon_site/dashboard/frontend/src/components/general/Header/Header.js
+++ b/hackathon_site/dashboard/frontend/src/components/general/Header/Header.js
@@ -11,7 +11,7 @@ import Menu from "@material-ui/icons/Menu";
 import CloseIcon from "@material-ui/icons/Close";
 import { connect } from "react-redux";
 
-import { Navbar } from "components/general/Navbar/Navbar";
+import Navbar from "components/general/Navbar/Navbar";
 import { userSelector } from "slices/users/userSlice";
 import { cartQuantity } from "testing/mockData";
 import { hackathonName } from "constants.js";

--- a/hackathon_site/dashboard/frontend/src/components/general/Header/Header.js
+++ b/hackathon_site/dashboard/frontend/src/components/general/Header/Header.js
@@ -11,7 +11,7 @@ import Menu from "@material-ui/icons/Menu";
 import CloseIcon from "@material-ui/icons/Close";
 import { connect } from "react-redux";
 
-import Navbar from "components/general/Navbar/Navbar";
+import { Navbar } from "components/general/Navbar/Navbar";
 import { userSelector } from "slices/users/userSlice";
 import { cartQuantity } from "testing/mockData";
 import { hackathonName } from "constants.js";

--- a/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.js
+++ b/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.js
@@ -1,6 +1,7 @@
 import React from "react";
 import styles from "./Navbar.module.scss";
 import { Link } from "react-router-dom";
+import { push } from "connected-react-router";
 import { connect } from "react-redux";
 // Images and logos
 import DashboardIcon from "@material-ui/icons/Dashboard";
@@ -12,7 +13,9 @@ import { ReactComponent as Inventory } from "assets/images/icons/Hardware.svg";
 // Components
 import Button from "@material-ui/core/Button";
 
-const UnconnectedNavbar = ({ cartQuantity, pathname }) => (
+import { logout, logoutSelector } from "slices/users/userSlice";
+
+const UnconnectedNavbar = ({ logout, cartQuantity, pathname }) => (
     <nav className={styles.nav}>
         <div className={styles.navFlexDiv}>
             <Link to={"/"}>
@@ -79,6 +82,10 @@ const UnconnectedNavbar = ({ cartQuantity, pathname }) => (
         <Button
             aria-label="Logout"
             className={`${styles.navBtn} ${styles.navBtnLogout}`}
+            onClick={() => {
+                logout();
+                push("/");
+            }}
         >
             <b>Logout</b>
         </Button>
@@ -89,6 +96,6 @@ const mapStateToProps = (state) => ({
     pathname: state.router.location.pathname,
 });
 
-const Navbar = connect(mapStateToProps)(UnconnectedNavbar);
+const Navbar = connect(mapStateToProps, { logout: logout })(UnconnectedNavbar);
 
 export default Navbar;

--- a/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.js
+++ b/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.js
@@ -12,7 +12,7 @@ import { ReactComponent as Inventory } from "assets/images/icons/Hardware.svg";
 // Components
 import Button from "@material-ui/core/Button";
 
-import { logout, logoutSelector } from "slices/users/userSlice";
+import logout from "slices/users/userSlice";
 
 const UnconnectedNavbar = ({ logout, cartQuantity, pathname }) => (
     <nav className={styles.nav}>

--- a/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.js
+++ b/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.js
@@ -12,7 +12,7 @@ import { ReactComponent as Inventory } from "assets/images/icons/Hardware.svg";
 // Components
 import Button from "@material-ui/core/Button";
 
-import logout from "slices/users/userSlice";
+import { logout } from "slices/users/userSlice";
 
 const UnconnectedNavbar = ({ logout, cartQuantity, pathname }) => (
     <nav className={styles.nav}>

--- a/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.js
+++ b/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.js
@@ -14,7 +14,7 @@ import Button from "@material-ui/core/Button";
 
 import { logout } from "slices/users/userSlice";
 
-const UnconnectedNavbar = ({ logout, cartQuantity, pathname }) => (
+export const UnconnectedNavbar = ({ logout, cartQuantity, pathname }) => (
     <nav className={styles.nav}>
         <div className={styles.navFlexDiv}>
             <Link to={"/"}>
@@ -94,6 +94,4 @@ const mapStateToProps = (state) => ({
     pathname: state.router.location.pathname,
 });
 
-const Navbar = connect(mapStateToProps, { logout })(UnconnectedNavbar);
-
-export default Navbar;
+export const Navbar = connect(mapStateToProps, { logout })(UnconnectedNavbar);

--- a/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.js
+++ b/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.js
@@ -94,4 +94,6 @@ const mapStateToProps = (state) => ({
     pathname: state.router.location.pathname,
 });
 
-export const Navbar = connect(mapStateToProps, { logout })(UnconnectedNavbar);
+const Navbar = connect(mapStateToProps, { logout })(UnconnectedNavbar);
+
+export default Navbar;

--- a/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.js
+++ b/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.js
@@ -1,7 +1,6 @@
 import React from "react";
 import styles from "./Navbar.module.scss";
 import { Link } from "react-router-dom";
-import { push } from "connected-react-router";
 import { connect } from "react-redux";
 // Images and logos
 import DashboardIcon from "@material-ui/icons/Dashboard";
@@ -84,7 +83,6 @@ const UnconnectedNavbar = ({ logout, cartQuantity, pathname }) => (
             className={`${styles.navBtn} ${styles.navBtnLogout}`}
             onClick={() => {
                 logout();
-                push("/");
             }}
         >
             <b>Logout</b>

--- a/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.js
+++ b/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.js
@@ -94,6 +94,6 @@ const mapStateToProps = (state) => ({
     pathname: state.router.location.pathname,
 });
 
-const Navbar = connect(mapStateToProps, { logout: logout })(UnconnectedNavbar);
+const Navbar = connect(mapStateToProps, { logout })(UnconnectedNavbar);
 
 export default Navbar;

--- a/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.test.js
+++ b/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import Navbar from "./Navbar";
 import { styles } from "./Navbar.module.scss";
 import { withStoreAndRouter } from "testing/helpers";
@@ -29,5 +29,27 @@ describe("<Navbar />", () => {
 
             expect(container.querySelectorAll(".navActive").length).toBe(1);
         });
+    });
+
+    test("logout function is called when logout button is clicked", () => {
+        const handleLogoutSpy = jest.fn();
+
+        const { getByText, debug } = render(
+            withStoreAndRouter(
+                <Navbar
+                    cartQuantity={cartQuantity}
+                    pathname={"/"}
+                    logout={handleLogoutSpy}
+                />
+            )
+        );
+
+        // click logout button
+        const logOutButton = getByText("Logout").closest("button");
+        debug(logOutButton);
+        fireEvent.click(logOutButton);
+
+        // confirm that handler function was called
+        expect(handleLogoutSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.test.js
+++ b/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { fireEvent, render } from "@testing-library/react";
-import { Navbar, UnconnectedNavbar } from "./Navbar";
+import Navbar, { UnconnectedNavbar } from "./Navbar";
 import { styles } from "./Navbar.module.scss";
 import { withStoreAndRouter, withRouter } from "testing/helpers";
 import { cartQuantity } from "testing/mockData";

--- a/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.test.js
+++ b/hackathon_site/dashboard/frontend/src/components/general/Navbar/Navbar.test.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { fireEvent, render } from "@testing-library/react";
-import Navbar from "./Navbar";
+import { Navbar, UnconnectedNavbar } from "./Navbar";
 import { styles } from "./Navbar.module.scss";
-import { withStoreAndRouter } from "testing/helpers";
+import { withStoreAndRouter, withRouter } from "testing/helpers";
 import { cartQuantity } from "testing/mockData";
 
 describe("<Navbar />", () => {
@@ -34,9 +34,9 @@ describe("<Navbar />", () => {
     test("logout function is called when logout button is clicked", () => {
         const handleLogoutSpy = jest.fn();
 
-        const { getByText, debug } = render(
-            withStoreAndRouter(
-                <Navbar
+        const { getByText } = render(
+            withRouter(
+                <UnconnectedNavbar
                     cartQuantity={cartQuantity}
                     pathname={"/"}
                     logout={handleLogoutSpy}
@@ -46,7 +46,6 @@ describe("<Navbar />", () => {
 
         // click logout button
         const logOutButton = getByText("Logout").closest("button");
-        debug(logOutButton);
         fireEvent.click(logOutButton);
 
         // confirm that handler function was called

--- a/hackathon_site/dashboard/frontend/src/slices/users/userSlice.js
+++ b/hackathon_site/dashboard/frontend/src/slices/users/userSlice.js
@@ -101,9 +101,15 @@ export const logout = createAsyncThunk(
     async (arg, {dispatch, rejectWithValue}) => {
         try {
             const response = await post("/api/auth/logout/", null);
+            dispatch(push("/"));
             return response.data;
         } catch (e) {
-            console.log(e)
+            dispatch(
+                displaySnackbar({
+                    message: e.response.data.detail,
+                    options: { variant: "error" },
+                })
+            );
             return rejectWithValue({
                 status: e.response.status,
                 message: e.response.data,
@@ -147,6 +153,7 @@ const userSlice = createSlice({
             state.logout.isLoading = true;
         },
         [logout.fulfilled]: (state) => {
+            state.userData.user = null;
             state.isAuthenticated = false;
             state.logout.isLoading = false;
             state.logout.failure = null;

--- a/hackathon_site/dashboard/frontend/src/slices/users/userSlice.js
+++ b/hackathon_site/dashboard/frontend/src/slices/users/userSlice.js
@@ -98,7 +98,7 @@ export const logIn = createAsyncThunk(
 
 export const logout = createAsyncThunk(
     `${userReducerName}/logout`,
-    async (arg, {dispatch, rejectWithValue}) => {
+    async (arg, { dispatch, rejectWithValue }) => {
         try {
             const response = await post("/api/auth/logout/", null);
             dispatch(push("/"));
@@ -189,4 +189,4 @@ export const loginSelector = createSelector(
 export const logoutSelector = createSelector(
     [userSliceSelector],
     (userSlice) => userSlice.logout
-)
+);

--- a/hackathon_site/dashboard/frontend/src/slices/users/userSlice.js
+++ b/hackathon_site/dashboard/frontend/src/slices/users/userSlice.js
@@ -15,6 +15,10 @@ export const initialState = {
         isLoading: false,
         failure: null,
     },
+    logout: {
+        isLoading: false,
+        failure: null,
+    },
     isAuthenticated: false,
 };
 
@@ -92,6 +96,22 @@ export const logIn = createAsyncThunk(
     }
 );
 
+export const logout = createAsyncThunk(
+    `${userReducerName}/logout`,
+    async (arg, {dispatch, rejectWithValue}) => {
+        try {
+            const response = await post("/api/auth/logout/", null);
+            return response.data;
+        } catch (e) {
+            console.log(e)
+            return rejectWithValue({
+                status: e.response.status,
+                message: e.response.data,
+            });
+        }
+    }
+);
+
 // Slice
 const userSlice = createSlice({
     name: "user",
@@ -123,6 +143,18 @@ const userSlice = createSlice({
             state.login.isLoading = false;
             state.isAuthenticated = false;
         },
+        [logout.pending]: (state) => {
+            state.logout.isLoading = true;
+        },
+        [logout.fulfilled]: (state) => {
+            state.isAuthenticated = false;
+            state.logout.isLoading = false;
+            state.logout.failure = null;
+        },
+        [logout.rejected]: (state, action) => {
+            state.logout.failure = action.payload || { message: action.error.message };
+            state.logout.isLoading = false;
+        },
     },
 });
 
@@ -146,3 +178,8 @@ export const loginSelector = createSelector(
     [userSliceSelector],
     (userSlice) => userSlice.login
 );
+
+export const logoutSelector = createSelector(
+    [userSliceSelector],
+    (userSlice) => userSlice.logout
+)


### PR DESCRIPTION
## Overview

- Resolves IEEE-40
- Adds async thunk for log out
  - post to `user/logout`
  - display snack bar with response.data.details on failure
  - push to "/" after the request succeeds
- Adds states and reducer for log out
  - when pending:
    - sets `logout.loading` to true when pending
  - when fulfilled:
    - clears `userData.user` to `null` to allow redirect to log in page
    - sets `isAuthenticated`to false
    - clears other logout states
  - when rejected:
    - clears `loading` and sets `failure`
- connects logout to NavBar
- fixes bug in extracting csrf token from cookie
- fixes bug where csrf token does not get updated on subsequent login calls
- exports `UnconnectedNavbar` component
  - `Navbar` is no longer a default export
- added tests


## Unit Tests Created

- tests for logout thunk and reducers to check the aforementioned behaviours
- tests that UnconnectedNavbar component calls the log out handler


## Steps to QA

- run react project, sign in (through either react project or django sites). 
- click logout in the narbar and check that:
  - the page is redirected to log in
  - you are signed out on all the django pages and cannot make further requests (/admin and /swagger)
- sign in again, then sign out (on react site). do the same checks

