### PR TITLE
Post Delete Signals for Event/Profile and Registration/Application

### DIFF
--- a/hackathon_site/event/__init__.py
+++ b/hackathon_site/event/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "event.apps.EventConfig"

--- a/hackathon_site/event/apps.py
+++ b/hackathon_site/event/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class EventConfig(AppConfig):
     name = "event"
+
+    def ready(self):
+        from event import signals

--- a/hackathon_site/event/signals.py
+++ b/hackathon_site/event/signals.py
@@ -1,0 +1,10 @@
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+from event.models import Profile
+
+
+@receiver(post_delete, sender=Profile, dispatch_uid="profile_delete_signal")
+def delete_profile(sender, instance, **kwargs):
+    team = instance.team
+    if team.profiles.count() == 0:
+        team.delete()

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -55,12 +55,10 @@ class ProfileSignalTestCase(TestCase):
     def test_remove_team_when_empty(self):
         self.profile.delete()
         self.assertEqual(EventTeam.objects.count(), 0)
-        pass
 
     def test_cascade_on_delete_user(self):
         self.user.delete()
         self.assertEqual(EventTeam.objects.count(), 0)
-        pass
 
     def test_keep_team_when_not_empty(self):
         second_user = User.objects.create(
@@ -74,7 +72,6 @@ class ProfileSignalTestCase(TestCase):
         self.assertEqual(EventTeam.objects.count(), 1)
         second_profile.delete()
         self.assertEqual(EventTeam.objects.count(), 0)
-        pass
 
 
 class IndexViewTestCase(SetupUserMixin, TestCase):

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -41,6 +41,42 @@ class ProfileTestCase(TestCase):
         self.assertEqual(EventTeam.objects.first(), profile.team)
 
 
+class ProfileSignalTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="foo@bar.com",
+            password="foobar123",
+            first_name="Foo",
+            last_name="Bar",
+        )
+        self.team = EventTeam.objects.create()
+        self.profile = Profile.objects.create(user=self.user, team=self.team)
+
+    def test_remove_team_when_empty(self):
+        self.profile.delete()
+        self.assertEqual(EventTeam.objects.count(), 0)
+        pass
+
+    def test_cascade_on_delete_user(self):
+        self.user.delete()
+        self.assertEqual(EventTeam.objects.count(), 0)
+        pass
+
+    def test_keep_team_when_not_empty(self):
+        second_user = User.objects.create(
+            username="bar@bar.com",
+            password="foobar123",
+            first_name="Foo",
+            last_name="Bar",
+        )
+        second_profile = Profile.objects.create(user=second_user, team=self.team)
+        self.profile.delete()
+        self.assertEqual(EventTeam.objects.count(), 1)
+        second_profile.delete()
+        self.assertEqual(EventTeam.objects.count(), 0)
+        pass
+
+
 class IndexViewTestCase(SetupUserMixin, TestCase):
     """
     Tests for the landing page template.

--- a/hackathon_site/registration/__init__.py
+++ b/hackathon_site/registration/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "registration.apps.RegistrationConfig"

--- a/hackathon_site/registration/apps.py
+++ b/hackathon_site/registration/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class RegistrationConfig(AppConfig):
     name = "registration"
+
+    def ready(self):
+        from registration import signals

--- a/hackathon_site/registration/signals.py
+++ b/hackathon_site/registration/signals.py
@@ -1,4 +1,4 @@
-from django.db.models.signals import post_delete, pre_save
+from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from registration.models import Application
 

--- a/hackathon_site/registration/signals.py
+++ b/hackathon_site/registration/signals.py
@@ -1,0 +1,11 @@
+from django.db.models.signals import post_delete, pre_save
+from django.dispatch import receiver
+from registration.models import Application
+
+
+@receiver(post_delete, sender=Application, dispatch_uid="application_delete_signal")
+def delete_application(sender, instance, **kwargs):
+    team = instance.team
+    if team.applications.count() == 0:
+        team.delete()
+    pass

--- a/hackathon_site/registration/signals.py
+++ b/hackathon_site/registration/signals.py
@@ -8,4 +8,3 @@ def delete_application(sender, instance, **kwargs):
     team = instance.team
     if team.applications.count() == 0:
         team.delete()
-    pass

--- a/hackathon_site/registration/tests.py
+++ b/hackathon_site/registration/tests.py
@@ -95,12 +95,10 @@ class ApplicationSignalTestCase(TestCase):
     def test_remove_team_when_empty(self):
         self.application.delete()
         self.assertEqual(RegistrationTeam.objects.count(), 0)
-        pass
 
     def test_cascade_on_delete_user(self):
         self.user.delete()
         self.assertEqual(RegistrationTeam.objects.count(), 0)
-        pass
 
     def test_keep_team_when_not_empty(self):
         second_user = User.objects.create(
@@ -116,4 +114,3 @@ class ApplicationSignalTestCase(TestCase):
         self.assertEqual(RegistrationTeam.objects.count(), 1)
         second_application.delete()
         self.assertEqual(RegistrationTeam.objects.count(), 0)
-        pass

--- a/hackathon_site/registration/tests.py
+++ b/hackathon_site/registration/tests.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
 from unittest.mock import MagicMock
 
+from hackathon_site.tests import SetupUserMixin
 from registration.views import SignUpView
+from registration.models import Team as RegistrationTeam, User
 
 
 class CustomSignUpViewTestCase(TestCase):
@@ -77,3 +79,41 @@ class CustomSignUpViewTestCase(TestCase):
 
         # Test that the plaintext email is the same as the html email
         self.assertEqual(plain_message, html_message)
+
+
+class ApplicationSignalTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="foo@bar.com",
+            password="foobar123",
+            first_name="Foo",
+            last_name="Bar",
+        )
+        self.team = RegistrationTeam.objects.create()
+        self.application = SetupUserMixin._apply_as_user(user=self.user, team=self.team)
+
+    def test_remove_team_when_empty(self):
+        self.application.delete()
+        self.assertEqual(RegistrationTeam.objects.count(), 0)
+        pass
+
+    def test_cascade_on_delete_user(self):
+        self.user.delete()
+        self.assertEqual(RegistrationTeam.objects.count(), 0)
+        pass
+
+    def test_keep_team_when_not_empty(self):
+        second_user = User.objects.create(
+            username="bar@bar.com",
+            password="foobar123",
+            first_name="Foo",
+            last_name="Bar",
+        )
+        second_application = SetupUserMixin._apply_as_user(
+            user=second_user, team=self.team
+        )
+        self.application.delete()
+        self.assertEqual(RegistrationTeam.objects.count(), 1)
+        second_application.delete()
+        self.assertEqual(RegistrationTeam.objects.count(), 0)
+        pass


### PR DESCRIPTION
## Overview

- Resolves IEEE-29
- Adds post delete signals for event profile and registration application
  - deletes associated teams if deletion resulted in empty team


## Unit Tests Created

- Tests both signals
  - Tests simple case when deleting the sole application/profile on a team
  - Tests cascading case when the sole user on a team is deleted
  - Tests that deletion is not performed when the team is not empty


## Steps to QA

- On admin site, make a user
- QA Registration:
  - Make a team and an application with that user
  - Delete that application. Verify that the team was also deleted
  - Now make another team and application with that user
  - Delete that user. Verify that both the application and team are deleted
  - Now make two users. Make one team and two applications (one for each user).
  - Delete one of the applications. Verify that the team is not deleted.
- QA Event
  - Same steps as above. Swap application for profile.

Note: make sure you are creating/checking the right team model.

