### PR TITLE
Connect Category Store

### DIFF
--- a/hackathon_site/dashboard/frontend/package.json
+++ b/hackathon_site/dashboard/frontend/package.json
@@ -63,10 +63,12 @@
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^13.1.8",
+    "@types/jest-when": "^2.7.3",
     "@types/react-redux": "^7.1.16",
     "@types/react-router-dom": "^5.1.7",
     "@types/redux-mock-store": "^1.0.3",
-    "husky": "^4.2.5"
+    "husky": "^4.2.5",
+    "jest-when": "^3.4.0"
   },
   "husky": {
     "hooks": {

--- a/hackathon_site/dashboard/frontend/src/api/api.ts
+++ b/hackathon_site/dashboard/frontend/src/api/api.ts
@@ -46,7 +46,8 @@ const makeConfig = () => ({
 });
 
 export const stripHostname = (url: string): string => {
-    return url.replace(SERVER_URL, "");
+    const parsed = new URL(url);
+    return parsed.pathname + parsed.search + parsed.hash;
 };
 
 export const get = <T>(

--- a/hackathon_site/dashboard/frontend/src/api/api.ts
+++ b/hackathon_site/dashboard/frontend/src/api/api.ts
@@ -45,6 +45,10 @@ const makeConfig = () => ({
     withCredentials: true,
 });
 
+export const stripHostname = (url: string): string => {
+    return url.replace(SERVER_URL, "");
+};
+
 export const get = <T>(
     uri: string,
     params?: { [key: string]: any }

--- a/hackathon_site/dashboard/frontend/src/components/inventory/InventoryFilter/InventoryFilter.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/InventoryFilter/InventoryFilter.test.tsx
@@ -42,29 +42,38 @@ describe("<InventoryFilter />", () => {
      * the level of the (mocked) API requests.
      */
 
+    const prepopulateStore = () => {
+        const apiResponse = makeMockApiListResponse(mockCategories);
+        mockedGet.mockResolvedValue(apiResponse);
+
+        const store = makeStore();
+        store.dispatch(getCategories());
+
+        return store;
+    };
+
     it("Submits selected filters", async () => {
-        const { getByText } = render(<InventoryFilter />);
+        const store = prepopulateStore();
+        const { getByText, findByText } = render(<InventoryFilter />, { store });
 
         const orderByNameButton = getByText("Z-A");
         const inStockCheckbox = getByText("In stock");
 
-        // TODO: Once categories are connected to the store,
-        //  some mocking will be required to populate this data
-        const mcuCheckbox = getByText("MCU_limit_3");
-        const FPGACheckbox = getByText("FPGA");
+        const firstCheckbox = await findByText(mockCategories[0].name);
+        const secondCheckbox = await findByText(mockCategories[1].name);
 
         const applyButton = getByText("Apply");
 
         fireEvent.click(orderByNameButton);
         fireEvent.click(inStockCheckbox);
-        fireEvent.click(mcuCheckbox);
-        fireEvent.click(FPGACheckbox);
+        fireEvent.click(firstCheckbox);
+        fireEvent.click(secondCheckbox);
         fireEvent.click(applyButton);
 
         const expectedFilters: HardwareFilters = {
             ordering: "-name",
             in_stock: true,
-            category_ids: [2, 3],
+            category_ids: [mockCategories[0].id, mockCategories[1].id],
         };
 
         await waitFor(() => {
@@ -73,19 +82,21 @@ describe("<InventoryFilter />", () => {
     });
 
     it("Clears filters when toggled", async () => {
-        const { getByText } = render(<InventoryFilter />);
+        const store = prepopulateStore();
+        const { getByText, findByText } = render(<InventoryFilter />, { store });
 
         const orderByNameButton = getByText("Z-A");
         const inStockCheckbox = getByText("In stock");
-        const FPGACheckbox = getByText("FPGA");
+        const firstCheckbox = await findByText(mockCategories[0].name);
+
         const applyButton = getByText("Apply");
 
         fireEvent.click(orderByNameButton);
         fireEvent.click(inStockCheckbox);
-        fireEvent.click(FPGACheckbox);
+        fireEvent.click(firstCheckbox);
 
         fireEvent.click(inStockCheckbox);
-        fireEvent.click(FPGACheckbox);
+        fireEvent.click(firstCheckbox);
         fireEvent.click(applyButton);
 
         const expectedFilters: HardwareFilters = {

--- a/hackathon_site/dashboard/frontend/src/components/inventory/InventoryFilter/InventoryFilter.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/InventoryFilter/InventoryFilter.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styles from "./InventoryFilter.module.scss";
 import { Formik, Field, FieldProps, FormikValues } from "formik";
 import Typography from "@material-ui/core/Typography";
@@ -11,10 +11,9 @@ import Radio from "@material-ui/core/Radio";
 import RadioGroup from "@material-ui/core/RadioGroup";
 import FormGroup from "@material-ui/core/FormGroup";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
-import { inventoryCategories } from "testing/mockData";
+import { connect, ConnectedProps, useDispatch, useSelector } from "react-redux";
 
 import { Category, HardwareFilters, HardwareOrdering } from "api/types";
-import { connect, ConnectedProps } from "react-redux";
 import {
     hardwareFiltersSelector,
     isLoadingSelector,
@@ -22,6 +21,10 @@ import {
     setFilters,
     clearFilters,
 } from "slices/hardware/hardwareSlice";
+import {
+    categorySelectors,
+    isLoadingSelector as isCategoriesLoadingSelector,
+} from "slices/hardware/categorySlice";
 import { RootState } from "slices/store";
 
 type OrderByOptions = {
@@ -94,73 +97,77 @@ interface InventoryFilterValues {
 }
 
 type InventoryFilterProps = FormikValues & {
-    categories: Category[];
     isLoading: boolean;
 };
 
 export const InventoryFilter = ({
     handleReset,
     handleSubmit,
-    categories,
     isLoading,
-}: InventoryFilterProps) => (
-    <div className={styles.filter}>
-        <Paper elevation={2} className={styles.filterPaper} square={true}>
-            <form onReset={handleReset} onSubmit={handleSubmit}>
-                <fieldset>
-                    <legend>
-                        <Typography variant="h2">Order by</Typography>
-                    </legend>
-                    <Field
-                        name="ordering"
-                        component={RadioOrderBy}
-                        options={orderByOptions}
-                    />
-                </fieldset>
-                <Divider className={styles.filterDivider} />
-                <fieldset>
-                    <legend>
-                        <Typography variant="h2">Availability</Typography>
-                    </legend>
-                    <Field name="in_stock" component={CheckboxAvailability} />
-                </fieldset>
-                <Divider className={styles.filterDivider} />
-                <fieldset>
-                    <legend>
-                        <Typography variant="h2">Categories</Typography>
-                    </legend>
-                    <Field
-                        name="categories"
-                        component={CheckboxCategory}
-                        options={categories}
-                    />
-                </fieldset>
-            </form>
-        </Paper>
-        <div className={styles.filterBtns}>
-            <Button
-                type="reset"
-                color="secondary"
-                onClick={handleReset}
-                disabled={isLoading}
-            >
-                Clear all
-            </Button>
-            <Button
-                type="submit"
-                onClick={handleSubmit}
-                color="primary"
-                variant="contained"
-                fullWidth={true}
-                className={styles.filterBtnsApply}
-                disabled={isLoading}
-                disableElevation
-            >
-                Apply
-            </Button>
+}: InventoryFilterProps) => {
+    const categories = useSelector(categorySelectors.selectAll);
+    const isCategoriesLoading = useSelector(isCategoriesLoadingSelector);
+
+    return (
+        <div className={styles.filter}>
+            <Paper elevation={2} className={styles.filterPaper} square={true}>
+                <form onReset={handleReset} onSubmit={handleSubmit}>
+                    <fieldset>
+                        <legend>
+                            <Typography variant="h2">Order by</Typography>
+                        </legend>
+                        <Field
+                            name="ordering"
+                            component={RadioOrderBy}
+                            options={orderByOptions}
+                        />
+                    </fieldset>
+                    <Divider className={styles.filterDivider} />
+                    <fieldset>
+                        <legend>
+                            <Typography variant="h2">Availability</Typography>
+                        </legend>
+                        <Field name="in_stock" component={CheckboxAvailability} />
+                    </fieldset>
+                    <Divider className={styles.filterDivider} />
+                    <fieldset>
+                        <legend>
+                            <Typography variant="h2">Categories</Typography>
+                        </legend>
+                        {isCategoriesLoading && "Loading"}
+                        <Field
+                            name="categories"
+                            component={CheckboxCategory}
+                            options={categories}
+                        />
+                    </fieldset>
+                </form>
+            </Paper>
+            <div className={styles.filterBtns}>
+                <Button
+                    type="reset"
+                    color="secondary"
+                    onClick={handleReset}
+                    disabled={isLoading}
+                >
+                    Clear all
+                </Button>
+                <Button
+                    type="submit"
+                    onClick={handleSubmit}
+                    color="primary"
+                    variant="contained"
+                    fullWidth={true}
+                    className={styles.filterBtnsApply}
+                    disabled={isLoading}
+                    disableElevation
+                >
+                    Apply
+                </Button>
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 export const EnhancedInventoryFilter = ({
     getHardwareWithFilters,
@@ -199,11 +206,7 @@ export const EnhancedInventoryFilter = ({
             validationOnChange={false}
         >
             {(formikProps) => (
-                <InventoryFilter
-                    {...formikProps}
-                    categories={inventoryCategories}
-                    isLoading={isLoading}
-                />
+                <InventoryFilter {...formikProps} isLoading={isLoading} />
             )}
         </Formik>
     );

--- a/hackathon_site/dashboard/frontend/src/components/inventory/InventoryFilter/InventoryFilter.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/InventoryFilter/InventoryFilter.tsx
@@ -126,7 +126,7 @@ export const InventoryFilter = ({ handleReset, handleSubmit }: FormikValues) => 
                             <Typography variant="h2">Categories</Typography>
                         </legend>
                         {isCategoriesLoading ? (
-                            <LinearProgress data-testid="circular-progress" />
+                            <LinearProgress data-testid="categories-linear-progress" />
                         ) : (
                             <Field
                                 name="categories"

--- a/hackathon_site/dashboard/frontend/src/components/inventory/InventorySearch/InventorySearch.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/InventorySearch/InventorySearch.test.tsx
@@ -11,7 +11,7 @@ import {
     initialState,
     HardwareState,
 } from "slices/hardware/hardwareSlice";
-import { makeStore, RootState } from "slices/store";
+import { RootState } from "slices/store";
 
 jest.mock("api/api");
 

--- a/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.test.tsx
@@ -1,30 +1,37 @@
 import React from "react";
 
-import { makeMockApiListResponse, render, waitFor } from "testing/utils";
+import { makeMockApiListResponse, render, waitFor, when } from "testing/utils";
 
 import Inventory from "pages/Inventory/Inventory";
-import { mockHardware } from "testing/mockData";
+import { mockCategories, mockHardware } from "testing/mockData";
 
 import { get } from "api/api";
-import InventoryFilter from "components/inventory/InventoryFilter/InventoryFilter";
 
 jest.mock("api/api");
 const mockedGet = get as jest.MockedFunction<typeof get>;
 
 const hardwareUri = "/api/hardware/hardware/";
+const categoriesUri = "/api/hardware/categories/";
 
 describe("Inventory Page", () => {
     it("Clears filters and fetches fresh data on load", () => {
         render(<Inventory />);
 
         expect(get).toHaveBeenCalledWith(hardwareUri, {});
+        expect(get).toHaveBeenCalledWith(categoriesUri);
     });
 
     it("Has necessary page elements", async () => {
         // Mock inventory data to make sure the inventory grid is being rendered
-        const apiResponse = makeMockApiListResponse(mockHardware);
+        const hardwareApiResponse = makeMockApiListResponse(mockHardware);
+        const categoryApiResponse = makeMockApiListResponse(mockCategories);
 
-        mockedGet.mockResolvedValue(apiResponse);
+        when(mockedGet)
+            .calledWith(hardwareUri, {})
+            .mockResolvedValue(hardwareApiResponse);
+        when(mockedGet)
+            .calledWith(categoriesUri)
+            .mockResolvedValue(categoryApiResponse);
 
         const { getByText } = render(<Inventory />);
 

--- a/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.test.tsx
@@ -22,7 +22,8 @@ describe("Inventory Page", () => {
     });
 
     it("Has necessary page elements", async () => {
-        // Mock inventory data to make sure the inventory grid is being rendered
+        // Mock inventory data to make sure the inventory grid and filters
+        // are being rendered
         const hardwareApiResponse = makeMockApiListResponse(mockHardware);
         const categoryApiResponse = makeMockApiListResponse(mockCategories);
 
@@ -37,6 +38,7 @@ describe("Inventory Page", () => {
 
         await waitFor(() => {
             expect(getByText(mockHardware[0].name)).toBeInTheDocument();
+            expect(getByText(mockCategories[0].name)).toBeInTheDocument();
         });
 
         expect(getByText(/load more/i)).toBeInTheDocument();

--- a/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { connect, ConnectedProps } from "react-redux";
+import { connect, ConnectedProps, useDispatch } from "react-redux";
 import Drawer from "@material-ui/core/Drawer";
 import Typography from "@material-ui/core/Typography";
 import Divider from "@material-ui/core/Divider";
@@ -17,17 +17,14 @@ import InventoryFilter from "components/inventory/InventoryFilter/InventoryFilte
 import InventoryGrid from "components/inventory/InventoryGrid/InventoryGrid";
 import ProductOverview from "components/inventory/ProductOverview/ProductOverview";
 
-import { RootState } from "slices/store";
 import { clearFilters, getHardwareWithFilters } from "slices/hardware/hardwareSlice";
 import { getCategories } from "slices/hardware/categorySlice";
 
 import { productInformation } from "testing/mockData";
 
-const UnconnectedInventory = ({
-    clearFilters,
-    getHardwareWithFilters,
-    getCategories,
-}: ConnectedInventoryProps) => {
+const Inventory = () => {
+    const dispatch = useDispatch();
+
     const [mobileOpen, setMobileOpen] = React.useState(false);
     const toggleFilter = () => {
         setMobileOpen(!mobileOpen);
@@ -46,10 +43,10 @@ const UnconnectedInventory = ({
 
     // When the page is loaded, clear filters and fetch fresh inventory data
     useEffect(() => {
-        clearFilters();
-        getHardwareWithFilters();
-        getCategories();
-    }, [clearFilters, getHardwareWithFilters, getCategories]);
+        dispatch(clearFilters());
+        dispatch(getHardwareWithFilters());
+        dispatch(getCategories());
+    }, [dispatch, clearFilters, getHardwareWithFilters, getCategories]);
 
     return (
         <>
@@ -138,16 +135,4 @@ const UnconnectedInventory = ({
     );
 };
 
-const mapStateToProps = (state: RootState) => ({});
-
-const connector = connect(mapStateToProps, {
-    clearFilters,
-    getHardwareWithFilters,
-    getCategories,
-});
-
-type ConnectedInventoryProps = ConnectedProps<typeof connector>;
-
-export const ConnectedInventory = connector(UnconnectedInventory);
-
-export default ConnectedInventory;
+export default Inventory;

--- a/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.tsx
@@ -19,12 +19,14 @@ import ProductOverview from "components/inventory/ProductOverview/ProductOvervie
 
 import { RootState } from "slices/store";
 import { clearFilters, getHardwareWithFilters } from "slices/hardware/hardwareSlice";
+import { getCategories } from "slices/hardware/categorySlice";
 
 import { productInformation } from "testing/mockData";
 
 const UnconnectedInventory = ({
     clearFilters,
     getHardwareWithFilters,
+    getCategories,
 }: ConnectedInventoryProps) => {
     const [mobileOpen, setMobileOpen] = React.useState(false);
     const toggleFilter = () => {
@@ -46,7 +48,8 @@ const UnconnectedInventory = ({
     useEffect(() => {
         clearFilters();
         getHardwareWithFilters();
-    }, [clearFilters, getHardwareWithFilters]);
+        getCategories();
+    }, [clearFilters, getHardwareWithFilters, getCategories]);
 
     return (
         <>
@@ -137,7 +140,11 @@ const UnconnectedInventory = ({
 
 const mapStateToProps = (state: RootState) => ({});
 
-const connector = connect(mapStateToProps, { clearFilters, getHardwareWithFilters });
+const connector = connect(mapStateToProps, {
+    clearFilters,
+    getHardwareWithFilters,
+    getCategories,
+});
 
 type ConnectedInventoryProps = ConnectedProps<typeof connector>;
 

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/categorySlice.test.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/categorySlice.test.ts
@@ -1,0 +1,115 @@
+import configureStore from "redux-mock-store";
+import thunk, { ThunkDispatch } from "redux-thunk";
+
+import store, { makeStore, RootState } from "slices/store";
+import {
+    categorySliceSelector,
+    categoryReducerName,
+    initialState,
+    getCategories,
+    categorySelectors,
+} from "slices/hardware/categorySlice";
+import { get, stripHostname } from "api/api";
+import { AnyAction } from "redux";
+import { displaySnackbar } from "slices/ui/uiSlice";
+import { mockCategories } from "testing/mockData";
+import { makeMockApiListResponse } from "testing/utils";
+
+jest.mock("api/api", () => ({
+    ...jest.requireActual("api/api"),
+    get: jest.fn(),
+}));
+
+const mockedGet = get as jest.MockedFunction<typeof get>;
+
+const mockState: RootState = {
+    ...store.getState(),
+    [categoryReducerName]: initialState,
+};
+
+type DispatchExts = ThunkDispatch<RootState, void, AnyAction>;
+const mockStore = configureStore<RootState, DispatchExts>([thunk]);
+
+describe("Selectors", () => {
+    test("categorySliceSelector returns the category store", () => {
+        expect(categorySliceSelector(mockState)).toEqual(
+            mockState[categoryReducerName]
+        );
+    });
+});
+
+describe("getCategories thunk", () => {
+    it("Dispatches a snackbar on API failure", async () => {
+        const failureResponse = {
+            response: {
+                status: 500,
+                message: "Something went wrong",
+            },
+        };
+
+        mockedGet.mockRejectedValue(failureResponse);
+
+        const store = mockStore(mockState);
+        await store.dispatch(getCategories());
+
+        const actions = store.getActions();
+
+        expect(actions).toContainEqual(
+            displaySnackbar({
+                message: "Failed to fetch category data: Error 500",
+                options: { variant: "error" },
+            })
+        );
+    });
+
+    it("Updates the store on API failure", async () => {
+        const failureResponse = {
+            response: {
+                status: 500,
+                message: "Something went wrong",
+            },
+        };
+
+        mockedGet.mockRejectedValue(failureResponse);
+
+        const store = makeStore();
+        await store.dispatch(getCategories());
+
+        expect(categorySliceSelector(store.getState())).toHaveProperty(
+            "error",
+            failureResponse.response.message
+        );
+    });
+
+    it("Exhaustively traverses the paginated API", async () => {
+        const next =
+            "http://localhost:8000/api/hardware/categories/?limit=100&offset=100";
+        const apiResponse1 = makeMockApiListResponse(
+            mockCategories.slice(0, 2),
+            next,
+            null,
+            4
+        );
+
+        const apiResponse2 = makeMockApiListResponse(
+            mockCategories.slice(2, 4),
+            null,
+            null,
+            4
+        );
+
+        mockedGet
+            .mockResolvedValueOnce(apiResponse1)
+            .mockResolvedValueOnce(apiResponse2);
+
+        const store = makeStore();
+        await store.dispatch(getCategories());
+
+        const categories = categorySelectors.selectAll(store.getState());
+        expect(categories).toEqual(categories.slice(0, 4));
+
+        expect(mockedGet).toHaveBeenCalledTimes(2);
+        expect(mockedGet).toHaveBeenCalledWith("/api/hardware/categories/");
+        expect(mockedGet).toHaveBeenCalledWith(stripHostname(next));
+    });
+});

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/categorySlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/categorySlice.ts
@@ -49,7 +49,7 @@ export const getCategories = createAsyncThunk<
             const response = await get<APIListResponse<Category>>(path);
             data = response.data;
             categories.push(...data.results);
-        } while (data.next !== null);
+        } while (data?.next !== null);
 
         return categories;
     } catch (e: any) {

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/categorySlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/categorySlice.ts
@@ -1,0 +1,104 @@
+import {
+    createSlice,
+    createEntityAdapter,
+    createSelector,
+    createAsyncThunk,
+} from "@reduxjs/toolkit";
+import { RootState, AppDispatch } from "slices/store";
+
+import { APIListResponse, Category } from "api/types";
+import { get, stripHostname } from "api/api";
+import { displaySnackbar } from "slices/ui/uiSlice";
+
+interface CategoryExtraState {
+    isLoading: boolean;
+    error: string | null;
+    next: string | null;
+}
+
+const extraState: CategoryExtraState = {
+    isLoading: false,
+    error: null,
+    next: null,
+};
+
+export const categoryReducerName = "category";
+const categoryAdapter = createEntityAdapter<Category>();
+export const initialState = categoryAdapter.getInitialState(extraState);
+export type CategoryState = typeof initialState;
+
+// Thunks
+interface RejectValue {
+    status: number;
+    message: any;
+}
+
+export const getCategories = createAsyncThunk<
+    Category[],
+    void,
+    { rejectValue: RejectValue; dispatch: AppDispatch }
+>(`${categoryReducerName}/getCategories`, async (_, { dispatch, rejectWithValue }) => {
+    try {
+        const categories: Category[] = [];
+        let data: APIListResponse<Category> | undefined = undefined;
+
+        let path: string = "/api/hardware/categories/";
+
+        do {
+            path = data?.next ? stripHostname(data.next) : path;
+            const response = await get<APIListResponse<Category>>(path);
+            data = response.data;
+            categories.push(...data.results);
+        } while (data.next !== null);
+
+        return categories;
+    } catch (e: any) {
+        dispatch(
+            displaySnackbar({
+                message: `Failed to fetch category data: Error ${e.response.status}`,
+                options: { variant: "error" },
+            })
+        );
+        return rejectWithValue({
+            status: e.response.status,
+            message: e.response.data,
+        });
+    }
+});
+
+// Slice
+const categorySlice = createSlice({
+    name: categoryReducerName,
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder.addCase(getCategories.pending, (state) => {
+            state.isLoading = true;
+            state.error = null;
+        });
+
+        builder.addCase(getCategories.fulfilled, (state, { payload }) => {
+            state.isLoading = false;
+            state.error = null;
+            categoryAdapter.setAll(state, payload);
+        });
+
+        builder.addCase(getCategories.rejected, (state, { payload }) => {
+            state.isLoading = false;
+            state.error = payload?.message || "Something went wrong";
+        });
+    },
+});
+
+export const { reducer } = categorySlice;
+export default reducer;
+
+// Selectors
+export const categorySliceSelector = (state: RootState) => state[categoryReducerName];
+
+export const categorySelectors = categoryAdapter.getSelectors(categorySliceSelector);
+
+export const isLoadingSelector = createSelector(
+    [categorySliceSelector],
+    (categorySlice) => categorySlice.isLoading
+);

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/categorySlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/categorySlice.ts
@@ -49,7 +49,7 @@ export const getCategories = createAsyncThunk<
             const response = await get<APIListResponse<Category>>(path);
             data = response.data;
             categories.push(...data.results);
-        } while (data?.next !== null);
+        } while (data?.next);
 
         return categories;
     } catch (e: any) {

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/hardwareSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/hardwareSlice.ts
@@ -67,7 +67,6 @@ export const getHardwareWithFilters = createAsyncThunk<
 );
 
 // Slice
-
 const hardwareSlice = createSlice({
     name: hardwareReducerName,
     initialState,

--- a/hackathon_site/dashboard/frontend/src/slices/store.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/store.ts
@@ -6,10 +6,12 @@ import { createBrowserHistory } from "history";
 import userReducer, { userReducerName } from "slices/users/userSlice";
 import uiReducer, { uiReducerName } from "slices/ui/uiSlice";
 import hardwareReducer, { hardwareReducerName } from "slices/hardware/hardwareSlice";
+import categoryReducer, { categoryReducerName } from "slices/hardware/categorySlice";
 
 export const history = createBrowserHistory();
 
 const reducers = {
+    [categoryReducerName]: categoryReducer,
     [hardwareReducerName]: hardwareReducer,
     [userReducerName]: userReducer,
     [uiReducerName]: uiReducer,

--- a/hackathon_site/dashboard/frontend/src/testing/mockData.tsx
+++ b/hackathon_site/dashboard/frontend/src/testing/mockData.tsx
@@ -152,7 +152,7 @@ export const addCartTest = () => {
 };
 
 // Inventory
-export const inventoryCategories: Category[] = [
+export const mockCategories: Category[] = [
     { id: 1, name: "MCU", max_per_team: 12, unique_hardware_count: 10 },
     { id: 2, name: "MCU_limit_3", max_per_team: 3, unique_hardware_count: 6 },
     { id: 3, name: "FPGA", max_per_team: 2, unique_hardware_count: 9 },

--- a/hackathon_site/dashboard/frontend/src/testing/utils.tsx
+++ b/hackathon_site/dashboard/frontend/src/testing/utils.tsx
@@ -66,12 +66,13 @@ export const promiseResolveWithDelay = <T extends unknown>(
 
 export const makeMockApiListResponse = <T extends unknown>(
     data: T[],
-    next?: string,
-    previous?: string
+    next?: string | null,
+    previous?: string | null,
+    count?: number
 ): AxiosResponse<APIListResponse<T>> =>
     ({
         data: {
-            count: data.length,
+            count: count ?? data.length,
             results: data,
             next: next || null,
             previous: previous || null,

--- a/hackathon_site/dashboard/frontend/src/testing/utils.tsx
+++ b/hackathon_site/dashboard/frontend/src/testing/utils.tsx
@@ -77,3 +77,6 @@ export const makeMockApiListResponse = <T extends unknown>(
             previous: previous || null,
         },
     } as AxiosResponse<APIListResponse<T>>);
+
+// Re-export everything from jest-when
+export * from "jest-when";

--- a/hackathon_site/dashboard/frontend/yarn.lock
+++ b/hackathon_site/dashboard/frontend/yarn.lock
@@ -1939,6 +1939,13 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest-when@^2.7.3":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@types/jest-when/-/jest-when-2.7.3.tgz#40735b320d8655ebff01123cb58afbdaf8274658"
+  integrity sha512-BdDZnKj3ZO1VsRlJFyRx6yLa0hG9++qetnBKhESjCGRVAm6S4aaKXXLm9xGFmtAQpzuMC44wxhvkG2cl6axvyQ==
+  dependencies:
+    "@types/jest" "*"
+
 "@types/jest@*":
   version "27.0.1"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.1.tgz#fafcc997da0135865311bb1215ba16dba6bdf4ca"
@@ -7056,6 +7063,11 @@ jest-watcher@^26.3.0, jest-watcher@^26.6.2:
     chalk "^4.0.0"
     jest-util "^26.6.2"
     string-length "^4.0.1"
+
+jest-when@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/jest-when/-/jest-when-3.4.0.tgz#2f78b80371cb2920067cb4cf8d88ee009a5dabd8"
+  integrity sha512-c7cj+uwoqik7w+CDpsKb5B5A7DhDU6MN9/KcXC+K4WdZHyAdV8zWWy7F+M42TYcQIgQNI2iRtFIf0zXUmVBSOQ==
 
 jest-worker@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
## Overview

- Connects the category API to our redux store, and the inventory filter where categories are displayed to the store
- Refactors the inventory filter component slightly to use redux hooks instead of connect()

## Unit Tests Created

- Integration style tests for the inventory page and filter, to make sure data is fetched and category filters are submitted
- Error tests for the thunk
- Thunk test for exhaustively querying the paginated API


## Steps to QA

- Create some categories and hardware via the Admin site if you haven't already
- Visit the Inventory page, make sure categories load properly
- Submit category filters, make sure they still work
- Bonus: Add over 100 categories to make sure pagination works, though I'm confident it does from the tests
