### PR TITLE
Upgrade Django to v3.2

### DIFF
--- a/hackathon_site/hackathon_site/settings/__init__.py
+++ b/hackathon_site/hackathon_site/settings/__init__.py
@@ -136,6 +136,8 @@ DATABASES = {
     }
 }
 
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
 # Cache
 # https://docs.djangoproject.com/en/3.1/topics/cache/
 REDIS_URI = os.environ.get("REDIS_URI", "172.17.0.1:6379/1")

--- a/hackathon_site/requirements.txt
+++ b/hackathon_site/requirements.txt
@@ -7,7 +7,7 @@ click==7.1.2
 coreapi==2.3.3
 coreschema==0.0.4
 dj-rest-auth==1.0.6
-Django==3.1.13
+Django==3.2.7
 django-cors-headers==3.3.0
 django-debug-toolbar==2.2.1
 django-filter==2.4.0


### PR DESCRIPTION
## Overview

- Keeping on top of things, this upgrades Django from v3.1 to v3.2
- No backwards incompatible changes that we need to worry about. The only thing that needed changing was specifyng the type of the default primary key field for models, as described [here](https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys)


## Unit Tests Created

- N/a


## Steps to QA

- Shouldn't need anything, tests should cover it

