### PR TITLE
Clean phone numbers in application

### DIFF
--- a/hackathon_site/registration/forms.py
+++ b/hackathon_site/registration/forms.py
@@ -11,7 +11,7 @@ from hackathon_site.utils import is_registration_open
 from registration.models import Application, Team, User
 from registration.widgets import MaterialFileInput
 
-
+import re
 class SignUpForm(UserCreationForm):
     """
     Form for registering a new user account.
@@ -171,6 +171,7 @@ class ApplicationForm(forms.ModelForm):
 
         self.instance.user = self.user
         self.instance.team = team
+        self.instance.phone_number = re.sub("[^0-9]", "", self.instance.phone_number)
 
         if commit:
             self.instance.save()

--- a/hackathon_site/registration/forms.py
+++ b/hackathon_site/registration/forms.py
@@ -12,6 +12,8 @@ from registration.models import Application, Team, User
 from registration.widgets import MaterialFileInput
 
 import re
+
+
 class SignUpForm(UserCreationForm):
     """
     Form for registering a new user account.

--- a/hackathon_site/registration/forms.py
+++ b/hackathon_site/registration/forms.py
@@ -13,6 +13,7 @@ from registration.widgets import MaterialFileInput
 
 import re
 
+
 class SignUpForm(UserCreationForm):
     """
     Form for registering a new user account.

--- a/hackathon_site/registration/forms.py
+++ b/hackathon_site/registration/forms.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+import re
 
 from django import forms
 from django.contrib.auth.forms import UserCreationForm
@@ -10,8 +11,6 @@ from django.conf import settings
 from hackathon_site.utils import is_registration_open
 from registration.models import Application, Team, User
 from registration.widgets import MaterialFileInput
-
-import re
 
 
 class SignUpForm(UserCreationForm):

--- a/hackathon_site/registration/forms.py
+++ b/hackathon_site/registration/forms.py
@@ -13,7 +13,6 @@ from registration.widgets import MaterialFileInput
 
 import re
 
-
 class SignUpForm(UserCreationForm):
     """
     Form for registering a new user account.

--- a/hackathon_site/registration/test_forms.py
+++ b/hackathon_site/registration/test_forms.py
@@ -191,6 +191,17 @@ class ApplicationFormTestCase(SetupUserMixin, TestCase):
             self.assertFalse(form.is_valid(), msg=number)
             self.assertIn("Enter a valid phone number.", form.errors["phone_number"])
 
+    def test_phone_number_clean_up(self):
+        unclean_to_clean_numbers = ("+1 (123) 246-7890", "11232467890")
+        
+        data = self.data.copy()
+        data["phone_number"] = unclean_to_clean_numbers[0]
+        form = self._build_form(data=data)
+        self.assertTrue(form.is_valid(), msg=form.errors)
+        application=form.save()
+       
+        self.assertEqual(application.phone_number, unclean_to_clean_numbers[1])
+
     def test_graduation_year_validator(self):
         def assert_bad_graduation_year(form):
             self.assertFalse(form.is_valid())

--- a/hackathon_site/registration/test_forms.py
+++ b/hackathon_site/registration/test_forms.py
@@ -193,13 +193,13 @@ class ApplicationFormTestCase(SetupUserMixin, TestCase):
 
     def test_phone_number_clean_up(self):
         unclean_to_clean_numbers = ("+1 (123) 246-7890", "11232467890")
-        
+
         data = self.data.copy()
         data["phone_number"] = unclean_to_clean_numbers[0]
         form = self._build_form(data=data)
         self.assertTrue(form.is_valid(), msg=form.errors)
-        application=form.save()
-       
+        application = form.save()
+
         self.assertEqual(application.phone_number, unclean_to_clean_numbers[1])
 
     def test_graduation_year_validator(self):


### PR DESCRIPTION
## Overview

- Resolves IEEE-59
- Removed all non numeric characters before saving to database

## Steps to QA

- Try submitting an application with a phone number that has non-numeric characters (ex: + 1 123-456 7890) and check that non-numeric characters are removed in the database

