### PR TITLE
IEEE-68: added permissions and tests for getting orders for regular participants

### DIFF
--- a/hackathon_site/event/api_urls.py
+++ b/hackathon_site/event/api_urls.py
@@ -14,5 +14,9 @@ urlpatterns = [
     ),
     path("teams/leave_team/", api_views.LeaveTeamView.as_view(), name="leave-team"),
     path("teams/", views.TeamListView.as_view(), name="team-list"),
-    path("teams/team/orders/", api_views.CurrentTeamOrdersView.as_view(), name="team-orders")
+    path(
+        "teams/team/orders/",
+        api_views.CurrentTeamOrderListView.as_view(),
+        name="team-orders",
+    ),
 ]

--- a/hackathon_site/event/api_urls.py
+++ b/hackathon_site/event/api_urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
     ),
     path("teams/leave_team/", api_views.LeaveTeamView.as_view(), name="leave-team"),
     path("teams/", views.TeamListView.as_view(), name="team-list"),
+    path("teams/team/orders/", api_views.CurrentTeamOrdersView.as_view(), name="team-orders")
 ]

--- a/hackathon_site/event/api_views.py
+++ b/hackathon_site/event/api_views.py
@@ -101,3 +101,11 @@ class JoinTeamView(generics.GenericAPIView, mixins.RetrieveModelMixin):
         response_serializer = TeamSerializer(profile.team)
         response_data = response_serializer.data
         return Response(data=response_data, status=status.HTTP_200_OK,)
+
+class CurrentTeamOrdersView(generics.GenericAPIView, mixins.RetrieveModelMixin):
+    queryset = Order.objects.filter(team_id=self.request.user.profile.team_id)
+    serializer_class = OrderListSerializer
+    permission_classes = [UserHasProfile]
+
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)

--- a/hackathon_site/event/api_views.py
+++ b/hackathon_site/event/api_views.py
@@ -9,7 +9,8 @@ from event.models import User, Team as EventTeam
 from event.serializers import UserSerializer, TeamSerializer
 from event.permissions import UserHasProfile
 
-from hardware.models import OrderItem
+from hardware.models import OrderItem, Order
+from hardware.serializers import OrderListSerializer
 
 
 class CurrentUserAPIView(generics.GenericAPIView, mixins.RetrieveModelMixin):
@@ -102,10 +103,13 @@ class JoinTeamView(generics.GenericAPIView, mixins.RetrieveModelMixin):
         response_data = response_serializer.data
         return Response(data=response_data, status=status.HTTP_200_OK,)
 
-class CurrentTeamOrdersView(generics.GenericAPIView, mixins.RetrieveModelMixin):
-    queryset = Order.objects.filter(team_id=self.request.user.profile.team_id)
+
+class CurrentTeamOrderListView(generics.ListAPIView):
     serializer_class = OrderListSerializer
     permission_classes = [UserHasProfile]
+
+    def get_queryset(self):
+        return Order.objects.filter(team_id=self.request.user.profile.team_id)
 
     def get(self, request, *args, **kwargs):
         return self.list(request, *args, **kwargs)

--- a/hackathon_site/event/test_api.py
+++ b/hackathon_site/event/test_api.py
@@ -366,3 +366,70 @@ class EventTeamListsViewTestCase(SetupUserMixin, APITestCase):
         results = data["results"]
         returned_ids = [res["team_code"] for res in results]
         self.assertCountEqual(returned_ids, [self.team2.team_code])
+
+
+class CurretnTeamOrderListViewTestCase(SetupUserMixin, APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.team = Team.objects.create()
+        self.order = Order.objects.create(status="Cart", team=self.team)
+        self.hardware = Hardware.objects.create(
+            name="name",
+            model_number="model",
+            manufacturer="manufacturer",
+            datasheet="/datasheet/location/",
+            notes="notes",
+            quantity_available=4,
+            max_per_team=1,
+            picture="/picture/location",
+        )
+        self.other_hardware = Hardware.objects.create(
+            name="other",
+            model_number="otherModel",
+            manufacturer="otherManufacturer",
+            datasheet="/datasheet/location/other",
+            quantity_available=10,
+            max_per_team=10,
+            picture="/picture/location/other",
+        )
+        OrderItem.objects.create(
+            order=self.order, hardware=self.hardware,
+        )
+        OrderItem.objects.create(
+            order=self.order, hardware=self.other_hardware,
+        )
+        
+        # making extra data to test if team data is being filtered
+        self.team2 = Team.objects.create(team_code="ABCDE")
+        Order.objects.create(status="Submitted", team=self.team2)
+        OrderItem.objects.create(
+            order=self.order_2, hardware=self.hardware,
+        )
+        OrderItem.objects.create(
+            order=self.order_2, hardware=self.other_hardware,
+        )
+        
+        self.view = reverse("api:event:team-orders)
+
+    def test_user_not_logged_in(self):
+        response = self.client.get(self.view)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_user_has_no_profile(self):
+        self._login()
+        response = self.client.get(self.view)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_has_profile(self):
+        Profile.objects.create(user=self.user, team=self.team)
+        self._login()
+        response = self.client.get(self.view)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        queryset = Order.objects.filter(team_id=self.team.id)
+
+        expected_response = OrderListSerializer(
+            queryset, many=True, context={"request": response.wsgi_request}
+        ).data
+        data = response.json()
+
+        self.assertEqual(expected_response, data["results"])

--- a/hackathon_site/event/test_api.py
+++ b/hackathon_site/event/test_api.py
@@ -11,6 +11,7 @@ from event.serializers import (
     TeamSerializer,
 )
 from hardware.models import Hardware, Order, OrderItem
+from hardware.serializers import OrderListSerializer
 
 
 class CurrentUserTestCase(SetupUserMixin, APITestCase):
@@ -368,7 +369,7 @@ class EventTeamListsViewTestCase(SetupUserMixin, APITestCase):
         self.assertCountEqual(returned_ids, [self.team2.team_code])
 
 
-class CurretnTeamOrderListViewTestCase(SetupUserMixin, APITestCase):
+class CurrentTeamOrderListViewTestCase(SetupUserMixin, APITestCase):
     def setUp(self):
         super().setUp()
         self.team = Team.objects.create()
@@ -398,18 +399,18 @@ class CurretnTeamOrderListViewTestCase(SetupUserMixin, APITestCase):
         OrderItem.objects.create(
             order=self.order, hardware=self.other_hardware,
         )
-        
+
         # making extra data to test if team data is being filtered
         self.team2 = Team.objects.create(team_code="ABCDE")
-        Order.objects.create(status="Submitted", team=self.team2)
+        self.order_2 = Order.objects.create(status="Submitted", team=self.team2)
         OrderItem.objects.create(
             order=self.order_2, hardware=self.hardware,
         )
         OrderItem.objects.create(
             order=self.order_2, hardware=self.other_hardware,
         )
-        
-        self.view = reverse("api:event:team-orders)
+
+        self.view = reverse("api:event:team-orders")
 
     def test_user_not_logged_in(self):
         response = self.client.get(self.view)

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -492,12 +492,12 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
         response = self.client.get(self.view)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_user_has_no_view_permissions_or_profile(self):
+    def test_user_has_no_view_permissions(self):
         self._login()
         response = self.client.get(self.view)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_user_has_view_permissions_but_no_profile(self):
+    def test_user_has_view_permissions(self):
         self._login(self.view_permissions)
         response = self.client.get(self.view)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -511,36 +511,7 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
 
         self.assertEqual(expected_response, data["results"])
 
-    def test_user_has_no_view_permissions_with_profile(self):
-        Profile.objects.create(user=self.user, team=self.team)
-        self._login()
-        response = self.client.get(self.view)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        queryset = Order.objects.filter(team_id=self.team.id)
-
-        expected_response = OrderListSerializer(
-            queryset, many=True, context={"request": response.wsgi_request}
-        ).data
-        data = response.json()
-
-        self.assertEqual(expected_response, data["results"])
-
-    def test_user_has_view_permissions_and_profile(self):
-        Profile.objects.create(user=self.user, team=self.team)
-        self._login(self.view_permissions)
-        response = self.client.get(self.view)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        queryset = Order.objects.all()
-
-        # need to provide a request in the serializer context to produce absolute url for image field
-        expected_response = OrderListSerializer(
-            queryset, many=True, context={"request": response.wsgi_request}
-        ).data
-        data = response.json()
-
-        self.assertEqual(expected_response, data["results"])
-
-    def test_hardware_get_success(self):
+    def test_orders_get_success(self):
         self._login(self.view_permissions)
 
         response = self.client.get(self.view)

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -481,7 +481,9 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
         self.view_permissions = Permission.objects.filter(
             content_type__app_label="hardware", codename="view_order"
         )
-        self.all_hardware_permissions = Permission.objects.filter(content_type__app_label="hardware")
+        self.all_hardware_permissions = Permission.objects.filter(
+            content_type__app_label="hardware"
+        )
         self.view = reverse("api:hardware:order-list")
 
     def _build_filter_url(self, **kwargs):
@@ -508,7 +510,7 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
         self._login(self.view_permissions)
         response = self.client.get(self.view)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        queryset = Order.objects.all().filter(team_id = self.team.id)
+        queryset = Order.objects.all().filter(team_id=self.team.id)
 
         # need to provide a request in the serializer context to produce absolute url for image field
         expected_response = OrderListSerializer(
@@ -596,7 +598,8 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
 
         returned_ids = [res["id"] for res in results]
         self.assertEqual(
-            returned_ids, [self.order.id, self.order_2.id, self.order_3.id, self.order_4.id]
+            returned_ids,
+            [self.order.id, self.order_2.id, self.order_3.id, self.order_4.id],
         )
 
     def test_created_at_ordering_descending(self):
@@ -610,7 +613,8 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
 
         returned_ids = [res["id"] for res in results]
         self.assertEqual(
-            returned_ids, [self.order_4.id, self.order_3.id, self.order_2.id, self.order.id]
+            returned_ids,
+            [self.order_4.id, self.order_3.id, self.order_2.id, self.order.id],
         )
 
     def test_search_filter(self):

--- a/hackathon_site/hardware/test_api.py
+++ b/hackathon_site/hardware/test_api.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from event.models import Team
+from event.models import Team, Profile, User
 from hardware.models import Hardware, Category, Order, OrderItem, Incident
 from hardware.serializers import (
     HardwareSerializer,
@@ -474,9 +474,14 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
         OrderItem.objects.create(
             order=self.order_3, hardware=self.hardware,
         )
-        self.permissions = Permission.objects.filter(
+        self.order_4 = Order.objects.create(status="Submitted", team=self.team2,)
+        OrderItem.objects.create(
+            order=self.order_4, hardware=self.hardware,
+        )
+        self.view_permissions = Permission.objects.filter(
             content_type__app_label="hardware", codename="view_order"
         )
+        self.all_hardware_permissions = Permission.objects.filter(content_type__app_label="hardware")
         self.view = reverse("api:hardware:order-list")
 
     def _build_filter_url(self, **kwargs):
@@ -493,8 +498,28 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
         response = self.client.get(self.view)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_user_has_view_permissions(self):
-        self._login(self.permissions)
+    def test_user_has_view_permissions_no_profile(self):
+        self._login(self.view_permissions)
+        response = self.client.get(self.view)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_has_view_permissions_with_profile(self):
+        Profile.objects.create(user=self.user, team=self.team)
+        self._login(self.view_permissions)
+        response = self.client.get(self.view)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        queryset = Order.objects.all().filter(team_id = self.team.id)
+
+        # need to provide a request in the serializer context to produce absolute url for image field
+        expected_response = OrderListSerializer(
+            queryset, many=True, context={"request": response.wsgi_request}
+        ).data
+        data = response.json()
+
+        self.assertEqual(expected_response, data["results"])
+
+    def test_user_has_change_permissions(self):
+        self._login(self.all_hardware_permissions)
         response = self.client.get(self.view)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         queryset = Order.objects.all()
@@ -508,7 +533,7 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
         self.assertEqual(expected_response, data["results"])
 
     def test_hardware_get_success(self):
-        self._login(self.permissions)
+        self._login(self.all_hardware_permissions)
 
         response = self.client.get(self.view)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -522,7 +547,7 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
         self.assertEqual(expected_response, data["results"])
 
     def test_team_id_filter(self):
-        self._login(self.permissions)
+        self._login(self.all_hardware_permissions)
 
         url = self._build_filter_url(team_id="1")
 
@@ -535,7 +560,7 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
         self.assertCountEqual(returned_ids, [self.order.id, self.order_2.id])
 
     def test_team_code_filter(self):
-        self._login(self.permissions)
+        self._login(self.all_hardware_permissions)
 
         url = self._build_filter_url(team_code="ABCDE")
 
@@ -545,10 +570,10 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
         results = data["results"]
 
         returned_ids = [res["id"] for res in results]
-        self.assertCountEqual(returned_ids, [self.order_3.id])
+        self.assertCountEqual(returned_ids, [self.order_3.id, self.order_4.id])
 
     def test_status_filter(self):
-        self._login(self.permissions)
+        self._login(self.all_hardware_permissions)
 
         url = self._build_filter_url(status="Cart")
 
@@ -561,7 +586,7 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
         self.assertCountEqual(returned_ids, [self.order.id])
 
     def test_created_at_ordering_ascending(self):
-        self._login(self.permissions)
+        self._login(self.all_hardware_permissions)
 
         url = self._build_filter_url(ordering="created_at")
         response = self.client.get(url)
@@ -571,11 +596,11 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
 
         returned_ids = [res["id"] for res in results]
         self.assertEqual(
-            returned_ids, [self.order.id, self.order_2.id, self.order_3.id]
+            returned_ids, [self.order.id, self.order_2.id, self.order_3.id, self.order_4.id]
         )
 
     def test_created_at_ordering_descending(self):
-        self._login(self.permissions)
+        self._login(self.all_hardware_permissions)
 
         url = self._build_filter_url(ordering="-created_at")
         response = self.client.get(url)
@@ -585,11 +610,11 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
 
         returned_ids = [res["id"] for res in results]
         self.assertEqual(
-            returned_ids, [self.order_3.id, self.order_2.id, self.order.id]
+            returned_ids, [self.order_4.id, self.order_3.id, self.order_2.id, self.order.id]
         )
 
     def test_search_filter(self):
-        self._login(self.permissions)
+        self._login(self.all_hardware_permissions)
 
         url = self._build_filter_url(search="ABCDE")
         response = self.client.get(url)
@@ -598,7 +623,34 @@ class OrderListViewGetTestCase(SetupUserMixin, APITestCase):
         results = data["results"]
 
         returned_ids = [res["id"] for res in results]
-        self.assertCountEqual(returned_ids, [self.order_3.id])
+        self.assertCountEqual(returned_ids, [self.order_3.id, self.order_4.id])
+
+    def test_status_filter_with_only_view_permissions(self):
+        Profile.objects.create(user=self.user, team=self.team)
+        self._login(self.view_permissions)
+
+        url = self._build_filter_url(status="Submitted")
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        results = data["results"]
+
+        returned_ids = [res["id"] for res in results]
+        self.assertCountEqual(returned_ids, [self.order_2.id])
+
+    def test_filter_from_another_team_with_only_view_permissions(self):
+        Profile.objects.create(user=self.user, team=self.team)
+        self._login(self.view_permissions)
+
+        url = self._build_filter_url(team_code="ABCDE")
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        results = data["results"]
+
+        self.assertEqual(results, [])
 
 
 class OrderListViewPostTestCase(SetupUserMixin, APITestCase):

--- a/hackathon_site/hardware/views.py
+++ b/hackathon_site/hardware/views.py
@@ -93,7 +93,7 @@ class OrderListView(generics.ListAPIView):
             # TODO: Causing problems with queryset aggregations, will figure out later:
             # .prefetch_related("hardware", "hardware__categories")
         )
-        if self.request.user.has_perm('hardware.change_order'):
+        if self.request.user.has_perm("hardware.change_order"):
             return queryset
         else:
             user_profile = Profile.objects.get(user_id=self.request.user.id)
@@ -109,7 +109,7 @@ class OrderListView(generics.ListAPIView):
         if self.request.method == "POST":
             return [UserHasProfile()]
         if self.request.method == "GET":
-            if self.request.user.has_perm('hardware.change_order'):
+            if self.request.user.has_perm("hardware.change_order"):
                 return [FullDjangoModelPermissions()]
             else:
                 return [UserHasProfile()]


### PR DESCRIPTION
## Overview

- Resolves [IEEE-68](https://ieeeuoft.atlassian.net/browse/IEEE-68)
- Added permission in order list view for regular participants
- if a user has a profile, it will filter by their team's orders, otherwise it will throw a 403 error
- if a user has change permissions, they get to see all orders


## Unit Tests Created

- Testing only view permissions with no profile
- Testing only view permissions with a profile
- Testing change permissions
- Testing filtering team's orders with view permissions and a profile
- Testing filtering another team's orders with with view permissions and a profile


## Steps to QA

- <Steps for a reviewer to QA your work> 

