### PR TITLE
IEEE-39 extend the team serializer to include team members

### DIFF
--- a/hackathon_site/event/serializers.py
+++ b/hackathon_site/event/serializers.py
@@ -16,7 +16,22 @@ class UserInSerializer(serializers.ModelSerializer):
         fields = ("id", "first_name", "last_name", "email")
 
 
-class ProfileSerializer(serializers.ModelSerializer):
+class ProfileInUserSerializer(serializers.ModelSerializer):
+    user = UserInSerializer(read_only=True)
+
+    class Meta:
+        model = Profile
+        fields = (
+            "id",
+            "id_provided",
+            "attended",
+            "acknowledge_rules",
+            "e_signature",
+            "user",
+        )
+
+
+class ProfileInTeamSerializer(serializers.ModelSerializer):
     user = UserInSerializer(read_only=True)
 
     class Meta:
@@ -32,7 +47,7 @@ class ProfileSerializer(serializers.ModelSerializer):
 
 
 class UserSerializer(serializers.ModelSerializer):
-    profile = ProfileSerializer(read_only=True)
+    profile = ProfileInUserSerializer(read_only=True)
     groups = GroupSerializer(many=True, read_only=True)
 
     class Meta:
@@ -41,7 +56,7 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class TeamSerializer(serializers.ModelSerializer):
-    profiles = ProfileSerializer(many=True, read_only=True)
+    profiles = ProfileInTeamSerializer(many=True, read_only=True)
 
     class Meta:
         model = Team
@@ -52,7 +67,3 @@ class TeamSerializer(serializers.ModelSerializer):
             "updated_at",
             "profiles",
         )
-
-    @staticmethod
-    def get_team_code(obj: Profile):
-        return obj.user.name

--- a/hackathon_site/event/serializers.py
+++ b/hackathon_site/event/serializers.py
@@ -10,7 +10,7 @@ class GroupSerializer(serializers.ModelSerializer):
         fields = ("id", "name")
 
 
-class UserInSerializer(serializers.ModelSerializer):
+class UserInProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ("id", "first_name", "last_name", "email")
@@ -31,7 +31,7 @@ class ProfileSerializer(serializers.ModelSerializer):
 
 
 class ProfileInUserSerializer(serializers.ModelSerializer):
-    user = UserInSerializer(read_only=True)
+    user = UserInProfileSerializer(read_only=True)
 
     class Meta:
         model = Profile
@@ -46,7 +46,7 @@ class ProfileInUserSerializer(serializers.ModelSerializer):
 
 
 class ProfileInTeamSerializer(serializers.ModelSerializer):
-    user = UserInSerializer(read_only=True)
+    user = UserInProfileSerializer(read_only=True)
 
     class Meta:
         model = Profile

--- a/hackathon_site/event/serializers.py
+++ b/hackathon_site/event/serializers.py
@@ -59,7 +59,6 @@ class ProfileInTeamSerializer(serializers.ModelSerializer):
             "user",
         )
 
-
     def update(self, instance: Profile, validated_data):
         return super().update(instance, validated_data)
 

--- a/hackathon_site/event/serializers.py
+++ b/hackathon_site/event/serializers.py
@@ -16,6 +16,19 @@ class UserInSerializer(serializers.ModelSerializer):
         fields = ("id", "first_name", "last_name", "email")
 
 
+class ProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Profile
+        fields = (
+            "id",
+            "id_provided",
+            "attended",
+            "acknowledge_rules",
+            "e_signature",
+            "team",
+        )
+
+
 class ProfileInUserSerializer(serializers.ModelSerializer):
     user = UserInSerializer(read_only=True)
 

--- a/hackathon_site/event/serializers.py
+++ b/hackathon_site/event/serializers.py
@@ -10,18 +10,15 @@ class GroupSerializer(serializers.ModelSerializer):
         fields = ("id", "name")
 
 
-class TeamSerializer(serializers.ModelSerializer):
+class UserInSerializer(serializers.ModelSerializer):
     class Meta:
-        model = Team
-        fields = (
-            "id",
-            "team_code",
-            "created_at",
-            "updated_at",
-        )
+        model = User
+        fields = ("id", "first_name", "last_name", "email")
 
 
 class ProfileSerializer(serializers.ModelSerializer):
+    user = UserInSerializer(read_only=True)
+
     class Meta:
         model = Profile
         fields = (
@@ -30,7 +27,7 @@ class ProfileSerializer(serializers.ModelSerializer):
             "attended",
             "acknowledge_rules",
             "e_signature",
-            "team",
+            "user",
         )
 
 
@@ -41,3 +38,21 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ("id", "first_name", "last_name", "email", "profile", "groups")
+
+
+class TeamSerializer(serializers.ModelSerializer):
+    profiles = ProfileSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Team
+        fields = (
+            "id",
+            "team_code",
+            "created_at",
+            "updated_at",
+            "profiles",
+        )
+
+    @staticmethod
+    def get_team_code(obj: Profile):
+        return obj.user.name

--- a/hackathon_site/event/test_api.py
+++ b/hackathon_site/event/test_api.py
@@ -293,7 +293,6 @@ class LeaveTeamTestCase(SetupUserMixin, APITestCase):
 
 class EventTeamListsViewTestCase(SetupUserMixin, APITestCase):
     def setUp(self):
-
         self.team = Team.objects.create()
         self.team2 = Team.objects.create()
         self.team3 = Team.objects.create()
@@ -307,6 +306,19 @@ class EventTeamListsViewTestCase(SetupUserMixin, APITestCase):
         return (
             self.view + "?" + "&".join([f"{key}={val}" for key, val in kwargs.items()])
         )
+
+    def test_team_id_filter(self):
+        self._login(self.permissions)
+
+        url = self._build_filter_url(team_ids="1,3")
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        results = data["results"]
+        print(results)
+        returned_ids = [res["id"] for res in results]
+        self.assertCountEqual(returned_ids, [1,3])
 
     def test_team_get_no_permissions(self):
         self._login()
@@ -344,18 +356,7 @@ class EventTeamListsViewTestCase(SetupUserMixin, APITestCase):
         returned_ids = [res["team_code"] for res in results]
         self.assertCountEqual(returned_ids, [self.team.team_code])
 
-    def test_team_id_filter(self):
-        self._login(self.permissions)
 
-        url = self._build_filter_url(team_ids="1,3")
-
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.json()
-        results = data["results"]
-
-        returned_ids = [res["id"] for res in results]
-        self.assertCountEqual(returned_ids, [1, 3])
 
     def test_name_search_filter(self):
         self._login(self.permissions)
@@ -471,3 +472,6 @@ class EventTeamDetailViewTestCase(SetupUserMixin, APITestCase):
         data = response.json()
 
         self.assertEqual(expected_response[0], data)
+
+
+

--- a/hackathon_site/event/test_api.py
+++ b/hackathon_site/event/test_api.py
@@ -316,7 +316,6 @@ class EventTeamListsViewTestCase(SetupUserMixin, APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         results = data["results"]
-        print(results)
         returned_ids = [res["id"] for res in results]
         self.assertCountEqual(returned_ids, [1, 3])
 

--- a/hackathon_site/event/test_api.py
+++ b/hackathon_site/event/test_api.py
@@ -318,7 +318,7 @@ class EventTeamListsViewTestCase(SetupUserMixin, APITestCase):
         results = data["results"]
         print(results)
         returned_ids = [res["id"] for res in results]
-        self.assertCountEqual(returned_ids, [1,3])
+        self.assertCountEqual(returned_ids, [1, 3])
 
     def test_team_get_no_permissions(self):
         self._login()
@@ -355,8 +355,6 @@ class EventTeamListsViewTestCase(SetupUserMixin, APITestCase):
 
         returned_ids = [res["team_code"] for res in results]
         self.assertCountEqual(returned_ids, [self.team.team_code])
-
-
 
     def test_name_search_filter(self):
         self._login(self.permissions)
@@ -472,6 +470,3 @@ class EventTeamDetailViewTestCase(SetupUserMixin, APITestCase):
         data = response.json()
 
         self.assertEqual(expected_response[0], data)
-
-
-

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from datetime import datetime, timedelta
 
 
-
 from django.core import mail
 from django.contrib.auth.models import Group
 from django.conf import settings
@@ -22,7 +21,7 @@ from event.serializers import (
     CurrentProfileSerializer,
     ProfileInUserSerializer,
     ProfileInTeamSerializer,
-    UserInSerializer,
+    UserInProfileSerializer,
 )
 
 
@@ -801,7 +800,7 @@ class ProfileInUserSerializerTestCase(TestCase):
             "attended": profile.attended,
             "acknowledge_rules": profile.acknowledge_rules,
             "e_signature": profile.e_signature,
-            "user": UserInSerializer(profile.user).data,
+            "user": UserInProfileSerializer(profile.user).data,
         }
 
         self.assertEqual(profile_expected, profile_serialized)
@@ -828,7 +827,7 @@ class ProfileInTeamSerilializerTestCase(TestCase):
             "attended": profile.attended,
             "acknowledge_rules": profile.acknowledge_rules,
             "e_signature": profile.e_signature,
-            "user": UserInSerializer(profile.user).data,
+            "user": UserInProfileSerializer(profile.user).data,
         }
 
         self.assertEqual(profile_expected, profile_serialized)

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -1,6 +1,8 @@
 import re
 from unittest.mock import patch
 from datetime import datetime, timedelta
+import json
+
 
 from django.core import mail
 from django.contrib.auth.models import Group
@@ -17,6 +19,9 @@ from event.serializers import (
     UserSerializer,
     GroupSerializer,
     ProfileSerializer,
+    ProfileInUserSerializer,
+    ProfileInTeamSerializer,
+    UserInSerializer,
 )
 
 
@@ -756,4 +761,58 @@ class ProfileSerializerTestCase(TestCase):
             "e_signature": profile.e_signature,
             "team": team.id,
         }
+        self.assertEqual(profile_expected, profile_serialized)
+
+
+class ProfileInUserSerializerTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="foo@bar.com",
+            password="foobar123",
+            first_name="Foo",
+            last_name="Bar",
+        )
+
+    def test_serializer(self):
+        team = EventTeam.objects.create()
+
+        profile = Profile.objects.create(user=self.user, team=team)
+        profile_serialized = ProfileInUserSerializer(profile).data
+
+        profile_expected = {
+            "id": profile.id,
+            "id_provided": profile.id_provided,
+            "attended": profile.attended,
+            "acknowledge_rules": profile.acknowledge_rules,
+            "e_signature": profile.e_signature,
+            "user": UserInSerializer(profile.user).data,
+        }
+
+        self.assertEqual(profile_expected, profile_serialized)
+
+
+class ProfileInTeamSerilializerTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="foo@bar.com",
+            password="foobar123",
+            first_name="Foo",
+            last_name="Bar",
+        )
+
+    def test_serializer(self):
+        team = EventTeam.objects.create()
+
+        profile = Profile.objects.create(user=self.user, team=team)
+        profile_serialized = ProfileInTeamSerializer(profile).data
+
+        profile_expected = {
+            "id": profile.id,
+            "id_provided": profile.id_provided,
+            "attended": profile.attended,
+            "acknowledge_rules": profile.acknowledge_rules,
+            "e_signature": profile.e_signature,
+            "user": UserInSerializer(profile.user).data,
+        }
+
         self.assertEqual(profile_expected, profile_serialized)

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -1,7 +1,7 @@
 import re
 from unittest.mock import patch
 from datetime import datetime, timedelta
-import json
+
 
 
 from django.core import mail

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -714,7 +714,7 @@ class UserSerializerTestCase(TestCase):
         )
 
         user_serialized = UserSerializer(user).data
-        profile_serialized = ProfileSerializer(user.profile).data
+        profile_serialized = ProfileInUserSerializer(user.profile).data
         group_serialized = GroupSerializer(user.groups, many=True).data
 
         user_expected = {
@@ -725,6 +725,7 @@ class UserSerializerTestCase(TestCase):
             "profile": profile_serialized,
             "groups": group_serialized,
         }
+
         self.assertEqual(user_expected, user_serialized)
 
 

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -729,6 +729,28 @@ class UserSerializerTestCase(TestCase):
         self.assertEqual(user_expected, user_serialized)
 
 
+class UserInProfileSerializerTestCase(TestCase):
+    def test_serializer(self):
+        team = EventTeam.objects.create()
+
+        user = User.objects.create()
+
+        Profile.objects.create(
+            user=user, team=team,
+        )
+
+        user_serialized = UserInProfileSerializer(user).data
+
+        user_expected = {
+            "id": user.id,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "email": user.email,
+        }
+
+        self.assertEqual(user_expected, user_serialized)
+
+
 class GroupSerializerTestCase(TestCase):
     def test_serializer(self):
         group = Group.objects.create(name="Test")


### PR DESCRIPTION
## Overview

TeamSerializer is used for the current team view, and will be used for list views on the tech team side. Currently, it doesn’t contain the team members, but it should (with their first name, last name, and email at least).

I would first look at removing the team serializer from the profile serializer if it’s still there (but leave it in the fields list, so it stays as just an ID). Then ProfileSerializercan be included in the team serializer. Add user fields to the profile serializer (by creating a UserInProfile serializer, since we can’t use the current UserSerializer). Update tests.

If that breaks too many tests, or seems like a bad idea (I can’t think of anywhere we’d need to get the full team from a profiles API endpoint, other than for the current user which we can get from the current team endpoint), then create a new ProfileInTeam serializer that has everything but the team in

## Unit Tests Created

Test whether the output of the new team serializer whether matches the expected result or not.



