### PR TITLE
added removeFromCart action and updated CartCard to dispatch action

### DIFF
--- a/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.test.tsx
@@ -1,10 +1,15 @@
 import React from "react";
 import CartCard from "components/cart/CartCard/CartCard";
 
-import { render, makeStoreWithEntities, waitFor } from "testing/utils";
-import { mockHardware } from "testing/mockData";
+import {
+    render,
+    makeStoreWithEntities,
+    waitFor,
+    fireEvent,
+    getByRole,
+} from "testing/utils";
+import { mockCartItems, mockHardware } from "testing/mockData";
 import { addToCart, cartSelectors } from "slices/hardware/cartSlice";
-import { fireEvent, getByRole } from "@testing-library/react";
 
 describe("<CartCard />", () => {
     /**
@@ -67,25 +72,25 @@ describe("<CartCard />", () => {
     });
 
     test("removeFromCart button", async () => {
-        const store = makeStoreWithEntities({ hardware: mockHardware });
+        const store = makeStoreWithEntities({ cartItems: mockCartItems });
 
         store.dispatch(
             addToCart({
-                hardware_id: mockHardware[0].id,
-                quantity: mockHardware[0].quantity_available,
+                hardware_id: mockCartItems[0].hardware_id,
+                quantity: mockCartItems[0].quantity,
             })
         );
         store.dispatch(
             addToCart({
-                hardware_id: mockHardware[1].id,
-                quantity: mockHardware[1].quantity_available,
+                hardware_id: mockCartItems[1].hardware_id,
+                quantity: mockCartItems[1].quantity,
             })
         );
 
         const { getByRole } = render(
             <CartCard
-                hardware_id={mockHardware[0].id}
-                quantity={mockHardware[0].quantity_available}
+                hardware_id={mockCartItems[0].hardware_id}
+                quantity={mockCartItems[0].quantity}
             />,
             { store }
         );
@@ -97,8 +102,8 @@ describe("<CartCard />", () => {
             expect(cartSelectors.selectAll(store.getState()).length).toEqual(1);
             expect(cartSelectors.selectAll(store.getState())).toEqual([
                 {
-                    hardware_id: mockHardware[1].id,
-                    quantity: mockHardware[1].quantity_available,
+                    hardware_id: mockCartItems[1].hardware_id,
+                    quantity: mockCartItems[1].quantity,
                 },
             ]);
         });

--- a/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.test.tsx
@@ -3,11 +3,12 @@ import CartCard from "components/cart/CartCard/CartCard";
 
 import { render, makeStoreWithEntities, waitFor } from "testing/utils";
 import { mockHardware } from "testing/mockData";
+import { addToCart, cartSelectors } from "slices/hardware/cartSlice";
+import { fireEvent, getByRole } from "@testing-library/react";
 
 describe("<CartCard />", () => {
     /**
      * TODO: Additional required tests once the redux slice is ready:
-     *  - Test that the remove button removes the item from the store
      *  - Test that updating the quantity updates the store
      */
 
@@ -62,6 +63,44 @@ describe("<CartCard />", () => {
 
         await waitFor(() => {
             expect(getByText(error)).toBeInTheDocument();
+        });
+    });
+
+    test("removeFromCart button", async () => {
+        const store = makeStoreWithEntities({ hardware: mockHardware });
+
+        store.dispatch(
+            addToCart({
+                hardware_id: mockHardware[0].id,
+                quantity: mockHardware[0].quantity_available,
+            })
+        );
+        store.dispatch(
+            addToCart({
+                hardware_id: mockHardware[1].id,
+                quantity: mockHardware[1].quantity_available,
+            })
+        );
+
+        const { getByRole } = render(
+            <CartCard
+                hardware_id={mockHardware[0].id}
+                quantity={mockHardware[0].quantity_available}
+            />,
+            { store }
+        );
+
+        const removeButton = getByRole("remove");
+        fireEvent.click(removeButton);
+
+        await waitFor(() => {
+            expect(cartSelectors.selectAll(store.getState()).length).toEqual(1);
+            expect(cartSelectors.selectAll(store.getState())).toEqual([
+                {
+                    hardware_id: mockHardware[1].id,
+                    quantity: mockHardware[1].quantity_available,
+                },
+            ]);
         });
     });
 });

--- a/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.test.tsx
@@ -7,6 +7,8 @@ import {
     waitFor,
     fireEvent,
     getByRole,
+    getByText,
+    queryByText,
 } from "testing/utils";
 import { mockCartItems, mockHardware } from "testing/mockData";
 import { addToCart, cartSelectors } from "slices/hardware/cartSlice";
@@ -72,7 +74,10 @@ describe("<CartCard />", () => {
     });
 
     test("removeFromCart button", async () => {
-        const store = makeStoreWithEntities({ cartItems: mockCartItems });
+        const store = makeStoreWithEntities({
+            hardware: mockHardware,
+            cartItems: mockCartItems,
+        });
 
         store.dispatch(
             addToCart({
@@ -80,6 +85,7 @@ describe("<CartCard />", () => {
                 quantity: mockCartItems[0].quantity,
             })
         );
+
         store.dispatch(
             addToCart({
                 hardware_id: mockCartItems[1].hardware_id,
@@ -87,7 +93,7 @@ describe("<CartCard />", () => {
             })
         );
 
-        const { getByRole } = render(
+        const { getByRole, queryByText } = render(
             <CartCard
                 hardware_id={mockCartItems[0].hardware_id}
                 quantity={mockCartItems[0].quantity}
@@ -99,13 +105,7 @@ describe("<CartCard />", () => {
         fireEvent.click(removeButton);
 
         await waitFor(() => {
-            expect(cartSelectors.selectAll(store.getState()).length).toEqual(1);
-            expect(cartSelectors.selectAll(store.getState())).toEqual([
-                {
-                    hardware_id: mockCartItems[1].hardware_id,
-                    quantity: mockCartItems[1].quantity,
-                },
-            ]);
+            expect(queryByText(mockHardware[0].picture)).not.toBeInTheDocument();
         });
     });
 });

--- a/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.test.tsx
@@ -1,17 +1,8 @@
 import React from "react";
 import CartCard from "components/cart/CartCard/CartCard";
 
-import {
-    render,
-    makeStoreWithEntities,
-    waitFor,
-    fireEvent,
-    getByRole,
-    getByText,
-    queryByText,
-} from "testing/utils";
-import { mockCartItems, mockHardware } from "testing/mockData";
-import { addToCart, cartSelectors } from "slices/hardware/cartSlice";
+import { render, makeStoreWithEntities, waitFor } from "testing/utils";
+import { mockHardware } from "testing/mockData";
 
 describe("<CartCard />", () => {
     /**
@@ -70,42 +61,6 @@ describe("<CartCard />", () => {
 
         await waitFor(() => {
             expect(getByText(error)).toBeInTheDocument();
-        });
-    });
-
-    test("removeFromCart button", async () => {
-        const store = makeStoreWithEntities({
-            hardware: mockHardware,
-            cartItems: mockCartItems,
-        });
-
-        store.dispatch(
-            addToCart({
-                hardware_id: mockCartItems[0].hardware_id,
-                quantity: mockCartItems[0].quantity,
-            })
-        );
-
-        store.dispatch(
-            addToCart({
-                hardware_id: mockCartItems[1].hardware_id,
-                quantity: mockCartItems[1].quantity,
-            })
-        );
-
-        const { getByRole, queryByText } = render(
-            <CartCard
-                hardware_id={mockCartItems[0].hardware_id}
-                quantity={mockCartItems[0].quantity}
-            />,
-            { store }
-        );
-
-        const removeButton = getByRole("remove");
-        fireEvent.click(removeButton);
-
-        await waitFor(() => {
-            expect(queryByText(mockHardware[0].picture)).not.toBeInTheDocument();
         });
     });
 });

--- a/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.tsx
@@ -12,9 +12,10 @@ import MenuItem from "@material-ui/core/MenuItem";
 import IconButton from "@material-ui/core/IconButton";
 import CloseIcon from "@material-ui/icons/Close";
 
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "slices/store";
 import { hardwareSelectors } from "slices/hardware/hardwareSlice";
+import { removeFromCart } from "slices/hardware/cartSlice";
 
 const makeSelections = (quantity_remaining: number) => {
     const items = [];
@@ -87,8 +88,10 @@ export const CartCard = ({ hardware_id, quantity, error }: CartCardProps) => {
         setNumInCart(parseInt(event.target.value));
     };
 
+    const dispatch = useDispatch();
+
     const handleRemove = (id: number) => {
-        alert(`Removing ${id}`);
+        dispatch(removeFromCart(id));
     };
 
     return hardware ? (
@@ -119,7 +122,7 @@ export const CartCard = ({ hardware_id, quantity, error }: CartCardProps) => {
                     size="small"
                     className={styles.CartClose}
                     onClick={() => {
-                        handleRemove(hardware.id);
+                        handleRemove(hardware_id);
                     }}
                     role="remove"
                 >

--- a/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.tsx
@@ -124,7 +124,7 @@ export const CartCard = ({ hardware_id, quantity, error }: CartCardProps) => {
                     onClick={() => {
                         handleRemove(hardware_id);
                     }}
-                    data-testid={hardware_id.toString()}
+                    data-testid={"cart-item-" + hardware_id.toString()}
                 >
                     <CloseIcon />
                 </IconButton>

--- a/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.tsx
@@ -124,7 +124,7 @@ export const CartCard = ({ hardware_id, quantity, error }: CartCardProps) => {
                     onClick={() => {
                         handleRemove(hardware_id);
                     }}
-                    role="remove"
+                    data-testid={hardware_id.toString()}
                 >
                     <CloseIcon />
                 </IconButton>

--- a/hackathon_site/dashboard/frontend/src/pages/Cart/Cart.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Cart/Cart.test.tsx
@@ -6,9 +6,6 @@ import {
     waitFor,
     promiseResolveWithDelay,
     makeMockApiListResponse,
-    getByTestId,
-    getByText,
-    queryByTestId,
     fireEvent,
 } from "testing/utils";
 import { mockCartItems, mockHardware } from "testing/mockData";
@@ -104,15 +101,17 @@ describe("Cart Page", () => {
             cartItems: mockCartItems,
         });
 
-        const { getByTestId, queryByTestId, getByText } = render(<Cart />, {
+        const { getByTestId, queryByText, getByText } = render(<Cart />, {
             store,
         });
 
-        const removeButton = getByTestId(mockCartItems[2].hardware_id.toString());
+        const removeButton = getByTestId(
+            "cart-item-" + mockCartItems[2].hardware_id.toString()
+        );
         fireEvent.click(removeButton);
 
         await waitFor(() => {
-            expect(queryByTestId(mockHardware[2].name)).not.toBeInTheDocument();
+            expect(queryByText(mockHardware[2].name)).not.toBeInTheDocument();
             expect(getByText(mockHardware[1].name)).toBeInTheDocument();
         });
     });

--- a/hackathon_site/dashboard/frontend/src/pages/Cart/Cart.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Cart/Cart.test.tsx
@@ -6,6 +6,10 @@ import {
     waitFor,
     promiseResolveWithDelay,
     makeMockApiListResponse,
+    getByTestId,
+    getByText,
+    queryByTestId,
+    fireEvent,
 } from "testing/utils";
 import { mockCartItems, mockHardware } from "testing/mockData";
 import { get } from "api/api";
@@ -92,5 +96,24 @@ describe("Cart Page", () => {
         expect(getByText(/no items in cart/i)).toBeInTheDocument();
         // Test for quantity
         expect(getByText(0)).toBeInTheDocument();
+    });
+
+    test("removeFromCart button", async () => {
+        const store = makeStoreWithEntities({
+            hardware: mockHardware,
+            cartItems: mockCartItems,
+        });
+
+        const { getByTestId, queryByTestId, getByText } = render(<Cart />, {
+            store,
+        });
+
+        const removeButton = getByTestId(mockCartItems[2].hardware_id.toString());
+        fireEvent.click(removeButton);
+
+        await waitFor(() => {
+            expect(queryByTestId(mockHardware[2].name)).not.toBeInTheDocument();
+            expect(getByText(mockHardware[1].name)).toBeInTheDocument();
+        });
     });
 });

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/cartSlice.test.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/cartSlice.test.ts
@@ -88,10 +88,16 @@ describe("removeFromCart action", () => {
         const store = makeStore();
 
         store.dispatch(addToCart({ hardware_id: 2, quantity: 1 }));
+
         store.dispatch(removeFromCart(2));
+        store.dispatch(addToCart({ hardware_id: 2, quantity: 5 }));
 
         await waitFor(() => {
-            expect(cartSelectors.selectAll(store.getState()).length).toEqual(0);
+            expect(cartSelectors.selectAll(store.getState()).length).toEqual(1);
+            expect(cartSelectors.selectById(store.getState(), 2)).toEqual({
+                hardware_id: 2,
+                quantity: 5,
+            });
         });
     });
 });

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/cartSlice.test.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/cartSlice.test.ts
@@ -9,7 +9,7 @@ import {
     removeFromCart,
 } from "slices/hardware/cartSlice";
 import { makeStoreWithEntities, waitFor } from "testing/utils";
-import { mockCartItems, mockHardware } from "../../testing/mockData";
+import { mockCartItems, mockHardware } from "testing/mockData";
 
 const mockState: RootState = {
     ...store.getState(),

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/cartSlice.test.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/cartSlice.test.ts
@@ -6,6 +6,7 @@ import {
     cartSliceSelector,
     isLoadingSelector,
     initialState,
+    removeFromCart,
 } from "slices/hardware/cartSlice";
 import { waitFor } from "testing/utils";
 
@@ -78,6 +79,19 @@ describe("addToCart action", () => {
                 hardware_id: 2,
                 quantity: 3,
             });
+        });
+    });
+});
+
+describe("removeFromCart action", () => {
+    test("removeFromCart removes existing item", async () => {
+        const store = makeStore();
+
+        store.dispatch(addToCart({ hardware_id: 2, quantity: 1 }));
+        store.dispatch(removeFromCart(2));
+
+        await waitFor(() => {
+            expect(cartSelectors.selectAll(store.getState()).length).toEqual(0);
         });
     });
 });

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/cartSlice.test.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/cartSlice.test.ts
@@ -8,7 +8,8 @@ import {
     initialState,
     removeFromCart,
 } from "slices/hardware/cartSlice";
-import { waitFor } from "testing/utils";
+import { makeStoreWithEntities, waitFor } from "testing/utils";
+import { mockCartItems, mockHardware } from "../../testing/mockData";
 
 const mockState: RootState = {
     ...store.getState(),
@@ -85,19 +86,24 @@ describe("addToCart action", () => {
 
 describe("removeFromCart action", () => {
     test("removeFromCart removes existing item", async () => {
-        const store = makeStore();
-
-        store.dispatch(addToCart({ hardware_id: 2, quantity: 1 }));
+        const store = makeStoreWithEntities({
+            hardware: mockHardware,
+            cartItems: mockCartItems,
+        });
 
         store.dispatch(removeFromCart(2));
-        store.dispatch(addToCart({ hardware_id: 2, quantity: 5 }));
 
         await waitFor(() => {
-            expect(cartSelectors.selectAll(store.getState()).length).toEqual(1);
-            expect(cartSelectors.selectById(store.getState(), 2)).toEqual({
-                hardware_id: 2,
-                quantity: 5,
+            expect(cartSelectors.selectAll(store.getState()).length).toEqual(2);
+            expect(cartSelectors.selectById(store.getState(), 1)).toEqual({
+                hardware_id: 1,
+                quantity: 3,
             });
+            expect(cartSelectors.selectById(store.getState(), 3)).toEqual({
+                hardware_id: 3,
+                quantity: 2,
+            });
+            expect(cartSelectors.selectById(store.getState(), 2)).toEqual(undefined);
         });
     });
 });

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/cartSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/cartSlice.ts
@@ -23,7 +23,7 @@ const cartAdapter = createEntityAdapter<CartItem>({
 
 export const cartReducerName = "cart";
 export const initialState = cartAdapter.getInitialState(extraState);
-export type CartItemState = typeof initialState;
+export type CartState = typeof initialState;
 
 // Slice
 const cartSlice = createSlice({

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/cartSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/cartSlice.ts
@@ -40,12 +40,15 @@ const cartSlice = createSlice({
                 cartAdapter.addOne(state, payload);
             }
         },
+        removeFromCart: (state, { payload }: PayloadAction<number>) => {
+            cartAdapter.removeOne(state, payload);
+        },
     },
 });
 
 export const { actions, reducer } = cartSlice;
 export default reducer;
-export const { addToCart } = actions;
+export const { addToCart, removeFromCart } = actions;
 
 // Selectors
 export const cartSliceSelector = (state: RootState) => state[cartReducerName];

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/cartSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/cartSlice.ts
@@ -23,6 +23,7 @@ const cartAdapter = createEntityAdapter<CartItem>({
 
 export const cartReducerName = "cart";
 export const initialState = cartAdapter.getInitialState(extraState);
+export type CartItemState = typeof initialState;
 
 // Slice
 const cartSlice = createSlice({

--- a/hackathon_site/dashboard/frontend/src/testing/utils.tsx
+++ b/hackathon_site/dashboard/frontend/src/testing/utils.tsx
@@ -10,7 +10,7 @@ import {
 import { makeStore, RootStore, RootState } from "slices/store";
 import { SnackbarProvider } from "notistack";
 import { AxiosResponse } from "axios";
-import { APIListResponse, Category, Hardware } from "api/types";
+import { APIListResponse, CartItem, Category, Hardware } from "api/types";
 import {
     hardwareReducerName,
     HardwareState,
@@ -21,6 +21,11 @@ import {
     CategoryState,
     initialState as categoryInitialState,
 } from "slices/hardware/categorySlice";
+import {
+    cartReducerName,
+    CartItemState,
+    initialState as cartItemInitialState,
+} from "slices/hardware/cartSlice";
 
 export const withRouter = (component: React.ComponentElement<any, any>) => (
     <BrowserRouter>{component}</BrowserRouter>
@@ -95,6 +100,7 @@ export * from "jest-when";
 export interface StoreEntities {
     hardware?: Hardware[];
     categories?: Category[];
+    cartItems?: CartItem[];
 }
 
 export const makeStoreWithEntities = (entities: StoreEntities) => {
@@ -127,6 +133,21 @@ export const makeStoreWithEntities = (entities: StoreEntities) => {
         }
 
         preloadedState[categoryReducerName] = categoryState;
+    }
+
+    if (entities.cartItems) {
+        const cartItemState: CartItemState = {
+            ...cartItemInitialState,
+            ids: [],
+            entities: {},
+        };
+
+        for (const cartItem of entities.cartItems) {
+            cartItemState.ids.push(cartItem.hardware_id);
+            cartItemState.entities[cartItem.hardware_id] = cartItem;
+        }
+
+        preloadedState[cartReducerName] = cartItemState;
     }
 
     return makeStore(preloadedState);

--- a/hackathon_site/dashboard/frontend/src/testing/utils.tsx
+++ b/hackathon_site/dashboard/frontend/src/testing/utils.tsx
@@ -23,7 +23,7 @@ import {
 } from "slices/hardware/categorySlice";
 import {
     cartReducerName,
-    CartItemState,
+    CartState,
     initialState as cartItemInitialState,
 } from "slices/hardware/cartSlice";
 
@@ -136,7 +136,7 @@ export const makeStoreWithEntities = (entities: StoreEntities) => {
     }
 
     if (entities.cartItems) {
-        const cartItemState: CartItemState = {
+        const cartItemState: CartState = {
             ...cartItemInitialState,
             ids: [],
             entities: {},


### PR DESCRIPTION
## Overview

- Resolves #331 
- This is Version 2 of the original Pull Request #330
- Created removeFromCart action
- Updated the “X” button in CartCard to dispatch this action.
- Allowed cartItems to be accepted into the makeStoreWithEntities function



## Unit Tests Created

- tested removeFromCart action by adding an item to the cart and then removing it, and checked if length of the store's state decreased
- added multiple items in cart and then dispatched removeFromCart and checked if the correct item was removed and what remained
- tested if the name of the hardware item, that was removed via the "X" button was in the Cart page, and the names that should still be there

## Steps to QA

- Go to cart page, once you click "add item to Cart", you can then click the "X" button to remove it from the cart.


