### PR TITLE
IEEE-136- Cart Card limits dropdown quantity by max per team constraints

### DIFF
--- a/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.test.tsx
@@ -14,7 +14,7 @@ describe("<CartCard />", () => {
         const store = makeStoreWithEntities({ hardware: mockHardware });
 
         const item = mockHardware[0];
-        const quantity = item.quantity_remaining - 1;
+        const quantity = item.quantity_remaining - 3;
 
         const { getByText, getByAltText } = render(
             <CartCard hardware_id={item.id} quantity={quantity} />,

--- a/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.tsx
@@ -37,13 +37,19 @@ interface QuantitySelectorProps {
     quantity_remaining: number;
     handleChange: (e: SelectChangeEvent) => void;
     numInCart: number;
+    constraintMax: number;
 }
 
 const QuantitySelector = ({
     quantity_remaining,
     numInCart,
     handleChange,
+    constraintMax,
 }: QuantitySelectorProps) => {
+    const dropdownNum = !constraintMax
+        ? quantity_remaining
+        : Math.min(quantity_remaining, constraintMax);
+
     if (!quantity_remaining) {
         return (
             <Typography variant="caption" className={styles.CartError}>
@@ -60,12 +66,13 @@ const QuantitySelector = ({
             <Select
                 label="Quantity"
                 labelId="QuantityLabel"
-                value={numInCart}
+                value={dropdownNum === 0 ? "" : numInCart}
                 // A bit of typescript hacking, since Select's onChange event has
                 // a value type of unknown and isn't a generic parameter.
                 onChange={handleChange as SelectProps["onChange"]}
+                disabled={dropdownNum === 0}
             >
-                {makeSelections(quantity_remaining)}
+                {makeSelections(dropdownNum)}
             </Select>
         </FormControl>
     );
@@ -122,6 +129,7 @@ export const CartCard = ({ hardware_id, quantity, error }: CartCardProps) => {
                     quantity_remaining={hardware.quantity_remaining}
                     handleChange={handleChange}
                     numInCart={quantity}
+                    constraintMax={hardware.max_per_team}
                 />
             </CardContent>
             <CardActions className={styles.CartAction}>

--- a/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/cart/CartCard/CartCard.tsx
@@ -52,7 +52,7 @@ const QuantitySelector = ({
             ? Math.min(quantity_remaining, maxPerTeam)
             : quantity_remaining;
 
-    if (!quantity_remaining) {
+    if (!dropdownNum) {
         return (
             <Typography variant="caption" className={styles.CartError}>
                 Currently unavailable

--- a/hackathon_site/dashboard/frontend/src/pages/Cart/Cart.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Cart/Cart.test.tsx
@@ -143,6 +143,7 @@ describe("Cart Page", () => {
         await waitFor(() => {
             expect(getByTestId("cart-quantity-total")).toHaveTextContent("4");
             expect(quantityDropdown).toHaveTextContent(quantityToBeSelected);
+            expect(quantityDropdown).not.toHaveTextContent("3");
         });
     });
 });

--- a/hackathon_site/dashboard/frontend/src/pages/Cart/Cart.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Cart/Cart.test.tsx
@@ -119,7 +119,7 @@ describe("Cart Page", () => {
     });
 
     test("updateCart action", async () => {
-        const quantityToBeSelected = "4";
+        const quantityToBeSelected = "1";
 
         const store = makeStoreWithEntities({
             hardware: mockHardware,
@@ -141,7 +141,7 @@ describe("Cart Page", () => {
         fireEvent.click(quantitySelected);
 
         await waitFor(() => {
-            expect(getByTestId("cart-quantity-total")).toHaveTextContent("7");
+            expect(getByTestId("cart-quantity-total")).toHaveTextContent("4");
             expect(quantityDropdown).toHaveTextContent(quantityToBeSelected);
         });
     });

--- a/hackathon_site/dashboard/frontend/src/pages/Cart/Cart.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Cart/Cart.tsx
@@ -18,6 +18,7 @@ import {
 } from "slices/hardware/hardwareSlice";
 import { RootState } from "slices/store";
 import { cartSelectors } from "slices/hardware/cartSlice";
+import { getCategories } from "slices/hardware/categorySlice";
 
 const Cart = () => {
     const cartItems = useSelector(cartSelectors.selectAll);
@@ -55,6 +56,7 @@ const Cart = () => {
             dispatch(clearFilters());
             dispatch(setFilters({ hardware_ids }));
             dispatch(getHardwareWithFilters({ keepOld: true }));
+            dispatch(getCategories());
         }
     }, [dispatch, hardware, isHardwareLoading, cartItems]);
 

--- a/hackathon_site/dashboard/frontend/src/testing/mockData.tsx
+++ b/hackathon_site/dashboard/frontend/src/testing/mockData.tsx
@@ -189,7 +189,7 @@ export const mockHardware: Hardware[] = [
         manufacturer: "Adafruit",
         datasheet: "https://example.com/datasheet",
         quantity_available: 10,
-        max_per_team: 7,
+        max_per_team: 2,
         picture: "https://i.imgur.com/iUpI1hC.jpg",
         categories: [1],
         quantity_remaining: 5,

--- a/hackathon_site/dashboard/frontend/src/testing/mockData.tsx
+++ b/hackathon_site/dashboard/frontend/src/testing/mockData.tsx
@@ -189,7 +189,7 @@ export const mockHardware: Hardware[] = [
         manufacturer: "Adafruit",
         datasheet: "https://example.com/datasheet",
         quantity_available: 10,
-        max_per_team: 2,
+        max_per_team: 7,
         picture: "https://i.imgur.com/iUpI1hC.jpg",
         categories: [1],
         quantity_remaining: 5,


### PR DESCRIPTION
## Overview

- Resolves IEEE-136
- Cart page limits quantity dropdown based on the hardware constraints(max_per_team).


## Unit Tests Created

- Altered the updateCart and CartCard render ui test since they were selecting a number beyond its max per team limit.

## Steps to QA

- Go to Cart Page, click on add to cart, and then check if the dropdown matches the item's max-per-team constraint 

