### PR TITLE
Include Order Items in the Order API

### DIFF
--- a/hackathon_site/dashboard/frontend/src/api/types.ts
+++ b/hackathon_site/dashboard/frontend/src/api/types.ts
@@ -78,8 +78,12 @@ export type OrderStatus = "Submitted" | "Ready for Pickup" | "Picked Up" | "Canc
 
 export interface Order {
     id: number;
-    hardware: Hardware[];
-    team: number;
+    items: {
+        id: number;
+        hardware_id: number;
+        part_returned_health: string | null;
+    }[];
+    team_id: number;
     team_code: string;
     status: OrderStatus;
     created_at: string;

--- a/hackathon_site/hardware/serializers.py
+++ b/hackathon_site/hardware/serializers.py
@@ -71,15 +71,25 @@ class IncidentListSerializer(IncidentCreateSerializer):
     order_item = OrderItemSerializer()
 
 
+class OrderItemInOrderSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = OrderItem
+        fields = (
+            "id",
+            "hardware",
+            "part_returned_health",
+        )
+
+
 class OrderListSerializer(serializers.ModelSerializer):
-    hardware = HardwareSerializer(many=True, read_only=True)
+    items = OrderItemInOrderSerializer(many=True, read_only=True)
     team_code = serializers.SerializerMethodField()
 
     class Meta:
         model = Order
         fields = (
             "id",
-            "hardware",
+            "items",
             "team",
             "team_code",
             "status",

--- a/hackathon_site/hardware/serializers.py
+++ b/hackathon_site/hardware/serializers.py
@@ -76,7 +76,7 @@ class OrderItemInOrderSerializer(serializers.ModelSerializer):
         model = OrderItem
         fields = (
             "id",
-            "hardware",
+            "hardware_id",
             "part_returned_health",
         )
 
@@ -90,7 +90,7 @@ class OrderListSerializer(serializers.ModelSerializer):
         fields = (
             "id",
             "items",
-            "team",
+            "team_id",
             "team_code",
             "status",
             "created_at",

--- a/hackathon_site/hardware/tests.py
+++ b/hackathon_site/hardware/tests.py
@@ -275,7 +275,7 @@ class OrderListSerializerTestCase(TestCase):
         order_serializer = OrderListSerializer(order).data
         expected_response = {
             "id": 1,
-            "team": self.team.id,
+            "team_id": self.team.id,
             "team_code": self.team.team_code,
             "status": "Cart",
             "items": [],

--- a/hackathon_site/hardware/tests.py
+++ b/hackathon_site/hardware/tests.py
@@ -278,7 +278,7 @@ class OrderListSerializerTestCase(TestCase):
             "team": self.team.id,
             "team_code": self.team.team_code,
             "status": "Cart",
-            "hardware": [],
+            "items": [],
             "created_at": serializers.DateTimeField().to_representation(
                 order.created_at
             ),
@@ -288,14 +288,12 @@ class OrderListSerializerTestCase(TestCase):
         }
         self.assertEqual(order_serializer, expected_response)
 
-    def test_hardware_set(self):
+    def test_order_with_items(self):
         order = Order.objects.create(status="Cart", team=self.team)
-        OrderItem.objects.create(
+        item_1 = OrderItem.objects.create(
             order=order, hardware=self.hardware, part_returned_health="Healthy"
         )
-        OrderItem.objects.create(
-            order=order, hardware=self.other_hardware,
-        )
+        item_2 = OrderItem.objects.create(order=order, hardware=self.other_hardware,)
         self.hardware.refresh_from_db()
         self.other_hardware.refresh_from_db()
         order_serializer = OrderListSerializer(order).data
@@ -304,9 +302,17 @@ class OrderListSerializerTestCase(TestCase):
             "team": self.team.id,
             "team_code": self.team.team_code,
             "status": "Cart",
-            "hardware": [
-                HardwareSerializer(self.hardware).data,
-                HardwareSerializer(self.other_hardware).data,
+            "items": [
+                {
+                    "id": item_1.id,
+                    "part_returned_health": "Healthy",
+                    "hardware": self.hardware.id,
+                },
+                {
+                    "id": item_2.id,
+                    "part_returned_health": None,
+                    "hardware": self.other_hardware.id,
+                },
             ],
             "created_at": serializers.DateTimeField().to_representation(
                 order.created_at

--- a/hackathon_site/hardware/tests.py
+++ b/hackathon_site/hardware/tests.py
@@ -299,19 +299,19 @@ class OrderListSerializerTestCase(TestCase):
         order_serializer = OrderListSerializer(order).data
         expected_response = {
             "id": 1,
-            "team": self.team.id,
+            "team_id": self.team.id,
             "team_code": self.team.team_code,
             "status": "Cart",
             "items": [
                 {
                     "id": item_1.id,
                     "part_returned_health": "Healthy",
-                    "hardware": self.hardware.id,
+                    "hardware_id": self.hardware.id,
                 },
                 {
                     "id": item_2.id,
                     "part_returned_health": None,
-                    "hardware": self.other_hardware.id,
+                    "hardware_id": self.other_hardware.id,
                 },
             ],
             "created_at": serializers.DateTimeField().to_representation(

--- a/hackathon_site/hardware/views.py
+++ b/hackathon_site/hardware/views.py
@@ -2,7 +2,6 @@ import logging
 
 from django_filters import rest_framework as filters
 from django.db import transaction
-from django.db.models import Prefetch, Count
 from django.http import HttpResponseServerError
 from drf_yasg.utils import swagger_auto_schema
 
@@ -12,7 +11,7 @@ from rest_framework.filters import SearchFilter, OrderingFilter
 
 from event.permissions import UserHasProfile, FullDjangoModelPermissions
 from hardware.api_filters import HardwareFilter, OrderFilter, IncidentFilter
-from hardware.models import Hardware, Category, Order, Incident, OrderItem
+from hardware.models import Hardware, Category, Order, Incident
 
 from hardware.serializers import (
     CategorySerializer,

--- a/hackathon_site/hardware/views.py
+++ b/hackathon_site/hardware/views.py
@@ -86,13 +86,7 @@ class CategoryListView(mixins.ListModelMixin, generics.GenericAPIView):
 
 
 class OrderListView(generics.ListAPIView):
-    queryset = (
-        Order.objects.all().select_related("team")
-        # TODO: Causing problems with queryset aggregations, will figure out later:
-        # .prefetch_related(
-        #     "items", "hardware", "hardware__categories", "items__hardware"
-        # )
-    )
+    queryset = Order.objects.all().select_related("team").prefetch_related("items",)
     serializer_method_classes = {
         "GET": OrderListSerializer,
         "POST": OrderCreateSerializer,
@@ -102,13 +96,6 @@ class OrderListView(generics.ListAPIView):
     filterset_class = OrderFilter
     ordering_fields = ("created_at",)
     search_fields = ("team__team_code", "id")
-
-    # def get_queryset(self):
-    #     return Order.objects.all().select_related("team").prefetch_related(
-    #         Prefetch("items", queryset=OrderItem.objects.annotate(
-    #             quantity_checked_out=
-    #         ))
-    #     )
 
     def get_serializer_class(self):
         try:


### PR DESCRIPTION
## Overview

The Order list API previously didn't give the `part_returned_health` of the order items, since it just included nested hardware.

Now it includes `items` directly, but no longer includes nested hardware - only hardware IDs. This is because the queryset annotation for `quantity_remaining` wouldn't work properly by including order items. Even before that it wasn't working with a prefetch related, so this view is now much more efficient.

On the frontend when fetching orders, we'll just need a separate request to fetch the associated hardware.

The response now looks like: 

```json
{
    "count": 2,
    "next": null,
    "previous": null,
    "results": [
        {
            "id": 5,
            "items": [
                {
                    "id": 8,
                    "hardware_id": 1,
                    "part_returned_health": null
                },
                {
                    "id": 9,
                    "hardware_id": 2,
                    "part_returned_health": "Healthy"
                },
                {
                    "id": 10,
                    "hardware_id": 1,
                    "part_returned_health": null
                }
            ],
            "team_id": 4,
            "team_code": "781B5",
            "status": "Submitted",
            "created_at": "2021-11-27T12:22:57.241253-05:00",
            "updated_at": "2021-11-27T13:33:44.277462-05:00"
        }
    ]
}
```

## Unit Tests Created

- Updated the unit tests for the order serializer.


## Steps to QA

- Visit http://localhost:8000/api/hardware/orders/, make sure all is in order. Nothing on the frontend uses this API yet.
