### PR TITLE
remove entity adapter from team slice

### DIFF
--- a/hackathon_site/dashboard/frontend/src/slices/event/teamSlice.test.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/event/teamSlice.test.ts
@@ -1,11 +1,11 @@
 import store, { makeStore, RootState } from "slices/store";
 import {
     teamReducerName,
-    teamSelectors,
     teamSliceSelector,
     isLoadingSelector,
     initialState,
     getCurrentTeam,
+    teamSelector,
 } from "slices/event/teamSlice";
 import { waitFor } from "testing/utils";
 import { mockTeam } from "testing/mockData";
@@ -29,7 +29,7 @@ describe("Selectors", () => {
         expect(teamSliceSelector(mockState)).toEqual(mockState[teamReducerName]);
     });
 
-    test("isLoadingSelector", () => {
+    test("isLoading Selector", () => {
         const loadingTrueState = {
             ...mockState,
             [teamReducerName]: {
@@ -47,6 +47,18 @@ describe("Selectors", () => {
         expect(isLoadingSelector(loadingTrueState)).toEqual(true);
         expect(isLoadingSelector(loadingFalseState)).toEqual(false);
     });
+
+    test("teamSelector returns the team", () => {
+        const teamState = {
+            ...mockState,
+            [teamReducerName]: {
+                ...initialState,
+                isLoading: false,
+                team: mockTeam,
+            },
+        };
+        expect(teamSelector(teamState)).toEqual(mockTeam);
+    });
 });
 
 describe("getCurrentTeam action", () => {
@@ -58,7 +70,7 @@ describe("getCurrentTeam action", () => {
         await store.dispatch(getCurrentTeam());
         await waitFor(() => {
             expect(mockedGet).toHaveBeenCalledWith("/api/event/teams/team/");
-            expect(teamSelectors.selectById(store.getState(), 1)).toEqual(mockTeam);
+            expect(store.getState()[teamReducerName].team).toEqual(mockTeam);
         });
     });
 });

--- a/hackathon_site/dashboard/frontend/src/slices/event/teamSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/event/teamSlice.ts
@@ -13,19 +13,16 @@ import { displaySnackbar } from "slices/ui/uiSlice";
 interface TeamExtraState {
     isLoading: boolean;
     error: string | null;
+    team: Team | null;
 }
 
-const extraState: TeamExtraState = {
+export const initialState: TeamExtraState = {
     isLoading: false,
     error: null,
+    team: null,
 };
 
-const teamAdapter = createEntityAdapter<Team>({
-    selectId: (entity) => entity.id,
-});
-
 export const teamReducerName = "team";
-export const initialState = teamAdapter.getInitialState(extraState);
 export type TeamState = typeof initialState;
 
 // Thunks
@@ -71,9 +68,9 @@ const teamSlice = createSlice({
             getCurrentTeam.fulfilled,
             (state, { payload }: PayloadAction<Team>) => {
                 if (payload) {
-                    teamAdapter.addOne(state, payload);
                     state.isLoading = false;
                     state.error = null;
+                    state.team = payload;
                 }
             }
         );
@@ -90,9 +87,12 @@ export default reducer;
 // Selectors
 export const teamSliceSelector = (state: RootState) => state[teamReducerName];
 
-export const teamSelectors = teamAdapter.getSelectors(teamSliceSelector);
-
 export const isLoadingSelector = createSelector(
     [teamSliceSelector],
     (teamSlice) => teamSlice.isLoading
+);
+
+export const teamSelector = createSelector(
+    [teamSliceSelector],
+    (teamSlice) => teamSlice.team
 );


### PR DESCRIPTION
## Overview

- removed entity adapter from team slice because not needed
- added selector for getting the team


## Unit Tests Created

- changed team slice tests


## Steps to QA

- no need to QA

