### PR TITLE
IEEE-128: updated categoryslice and test

### DIFF
--- a/hackathon_site/dashboard/frontend/src/pages/Dashboard/Dashboard.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Dashboard/Dashboard.test.tsx
@@ -27,56 +27,62 @@ const mockedGet = get as jest.MockedFunction<typeof get>;
 const hardwareUri = "/api/hardware/hardware/";
 const categoriesUri = "/api/hardware/categories/";
 
-it("Renders correctly when the dashboard appears 4 cards and 3 tables", () => {
-    const { queryByText, getByText } = render(<Dashboard />);
-    for (let e of cardItems) {
-        expect(queryByText(e.title)).toBeTruthy();
-    }
-    expect(getByText("Checked out items")).toBeInTheDocument();
-    expect(getByText("Pending Orders")).toBeInTheDocument();
-    // TODO: add check for returned items and broken items when those are ready
-});
+describe("Dashboard Page", () => {
+    it("Renders correctly when the dashboard appears 4 cards and 3 tables", () => {
+        const { queryByText, getByText } = render(<Dashboard />);
+        for (let e of cardItems) {
+            expect(queryByText(e.title)).toBeTruthy();
+        }
+        expect(getByText("Checked out items")).toBeInTheDocument();
+        expect(getByText("Pending Orders")).toBeInTheDocument();
+        // TODO: add check for returned items and broken items when those are ready
+    });
 
-it("Opens Product Overview with the correct hardware information", async () => {
-    const hardwareApiResponse = makeMockApiListResponse(mockHardware);
-    const categoryApiResponse = makeMockApiListResponse(mockCategories);
+    it("Opens Product Overview with the correct hardware information", async () => {
+        const hardwareApiResponse = makeMockApiListResponse(mockHardware);
+        const categoryApiResponse = makeMockApiListResponse(mockCategories);
 
-    const allOrders = mockPendingOrders.concat(mockCheckedOutOrders);
-    const hardware_ids = allOrders.flatMap((order) =>
-        order.items.map((item) => item.hardware_id)
-    );
-    when(mockedGet)
-        .calledWith(hardwareUri, { hardware_ids })
-        .mockResolvedValue(hardwareApiResponse);
-    when(mockedGet).calledWith(categoriesUri).mockResolvedValue(categoryApiResponse);
+        const allOrders = mockPendingOrders.concat(mockCheckedOutOrders);
+        const hardware_ids = allOrders.flatMap((order) =>
+            order.items.map((item) => item.hardware_id)
+        );
+        when(mockedGet)
+            .calledWith(hardwareUri, { hardware_ids })
+            .mockResolvedValue(hardwareApiResponse);
+        when(mockedGet)
+            .calledWith(categoriesUri, {})
+            .mockResolvedValue(categoryApiResponse);
 
-    const { getByTestId, getByText } = render(<Dashboard />);
+        const { getByTestId, getByText } = render(<Dashboard />);
 
-    const hardware = mockHardware.find(
-        ({ id }) => id === mockCheckedOutOrders[0].items[0].hardware_id
-    );
-    const category = mockCategories.find(({ id }) => id === hardware?.categories[0]);
+        const hardware = mockHardware.find(
+            ({ id }) => id === mockCheckedOutOrders[0].items[0].hardware_id
+        );
+        const category = mockCategories.find(
+            ({ id }) => id === hardware?.categories[0]
+        );
 
-    if (hardware && category) {
-        await waitFor(() => {
-            const infoButton = within(
-                getByTestId(
-                    `checked-out-hardware-${hardware.id}-${mockCheckedOutOrders[0].id}`
-                )
-            ).getByTestId("info-button");
-            fireEvent.click(infoButton);
-            expect(getByText("Product Overview")).toBeVisible();
-            expect(
-                getByText(`- Max ${hardware.max_per_team} of this item`)
-            ).toBeInTheDocument();
-            expect(
-                getByText(
-                    `- Max ${mockCategories[0].max_per_team} of items under category ${mockCategories[0].name}`
-                )
-            ).toBeInTheDocument();
-            expect(getByText(hardware.model_number)).toBeInTheDocument();
-            expect(getByText(hardware.manufacturer)).toBeInTheDocument();
-            expect(getByText(hardware.notes)).toBeInTheDocument();
-        });
-    }
+        if (hardware && category) {
+            await waitFor(() => {
+                const infoButton = within(
+                    getByTestId(
+                        `checked-out-hardware-${hardware.id}-${mockCheckedOutOrders[0].id}`
+                    )
+                ).getByTestId("info-button");
+                fireEvent.click(infoButton);
+                expect(getByText("Product Overview")).toBeVisible();
+                expect(
+                    getByText(`- Max ${hardware.max_per_team} of this item`)
+                ).toBeInTheDocument();
+                expect(
+                    getByText(
+                        `- Max ${mockCategories[0].max_per_team} of items under category ${mockCategories[0].name}`
+                    )
+                ).toBeInTheDocument();
+                expect(getByText(hardware.model_number)).toBeInTheDocument();
+                expect(getByText(hardware.manufacturer)).toBeInTheDocument();
+                expect(getByText(hardware.notes)).toBeInTheDocument();
+            });
+        }
+    });
 });

--- a/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.test.tsx
@@ -28,7 +28,7 @@ describe("Inventory Page", () => {
         render(<Inventory />);
 
         expect(get).toHaveBeenCalledWith(hardwareUri, {});
-        expect(get).toHaveBeenCalledWith(categoriesUri);
+        expect(get).toHaveBeenCalledWith(categoriesUri, {});
     });
 
     it("Has necessary page elements", async () => {
@@ -41,7 +41,7 @@ describe("Inventory Page", () => {
             .calledWith(hardwareUri, {})
             .mockResolvedValue(hardwareApiResponse);
         when(mockedGet)
-            .calledWith(categoriesUri)
+            .calledWith(categoriesUri, {})
             .mockResolvedValue(categoryApiResponse);
 
         const { getByText } = render(<Inventory />);
@@ -69,7 +69,7 @@ describe("Inventory Page", () => {
             .calledWith(hardwareUri, {})
             .mockResolvedValue(hardwareApiResponse);
         when(mockedGet)
-            .calledWith(categoriesUri)
+            .calledWith(categoriesUri, {})
             .mockResolvedValue(categoryApiResponse);
 
         const { getByText, getByTestId } = render(<Inventory />);
@@ -95,7 +95,7 @@ describe("Inventory Page", () => {
             .calledWith(hardwareUri, {})
             .mockResolvedValue(hardwareApiResponse);
         when(mockedGet)
-            .calledWith(categoriesUri)
+            .calledWith(categoriesUri, {})
             .mockResolvedValue(categoryApiResponse);
 
         const { getByText, queryByText, getByTestId } = render(<Inventory />);
@@ -127,7 +127,7 @@ describe("Inventory Page", () => {
             .calledWith(hardwareUri, {})
             .mockResolvedValue(hardwareApiResponse);
         when(mockedGet)
-            .calledWith(categoriesUri)
+            .calledWith(categoriesUri, {})
             .mockResolvedValue(categoryApiResponse);
 
         const { getByText } = render(<Inventory />);
@@ -181,7 +181,7 @@ describe("Inventory Page", () => {
             .calledWith(path, filters)
             .mockResolvedValue(hardwareNextApiResponse);
         when(mockedGet)
-            .calledWith(categoriesUri)
+            .calledWith(categoriesUri, {})
             .mockResolvedValue(categoryApiResponse);
 
         const { getByText, queryByText } = render(<Inventory />);
@@ -221,7 +221,7 @@ describe("Inventory Page", () => {
             .mockResolvedValueOnce(hardwareApiResponse)
             .mockResolvedValue(hardwareApiResponseAfterRefresh);
         when(mockedGet)
-            .calledWith(categoriesUri)
+            .calledWith(categoriesUri, {})
             .mockResolvedValue(categoryApiResponse);
 
         const { getByText, getByTestId, queryByText } = render(<Inventory />);
@@ -266,7 +266,7 @@ describe("Inventory Page", () => {
             .calledWith(path, filters)
             .mockReturnValue(promiseResolveWithDelay(hardwareNextApiResponse, 500));
         when(mockedGet)
-            .calledWith(categoriesUri)
+            .calledWith(categoriesUri, {})
             .mockResolvedValue(categoryApiResponse);
 
         const { getByText, queryByText, queryByTestId } = render(<Inventory />);

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/categorySlice.test.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/categorySlice.test.ts
@@ -9,7 +9,7 @@ import {
     getCategories,
     categorySelectors,
 } from "slices/hardware/categorySlice";
-import { get, stripHostname } from "api/api";
+import { get, stripHostnameReturnFilters } from "api/api";
 import { AnyAction } from "redux";
 import { displaySnackbar } from "slices/ui/uiSlice";
 import { mockCategories } from "testing/mockData";
@@ -112,6 +112,8 @@ describe("getCategories thunk", () => {
             4
         );
 
+        const { path: nextPath, filters } = stripHostnameReturnFilters(next);
+
         mockedGet
             .mockResolvedValueOnce(apiResponse1)
             .mockResolvedValueOnce(apiResponse2);
@@ -123,7 +125,7 @@ describe("getCategories thunk", () => {
         expect(categories).toEqual(categories.slice(0, 4));
 
         expect(mockedGet).toHaveBeenCalledTimes(2);
-        expect(mockedGet).toHaveBeenCalledWith("/api/hardware/categories/");
-        expect(mockedGet).toHaveBeenCalledWith(stripHostname(next));
+        expect(mockedGet).toHaveBeenCalledWith("/api/hardware/categories/", {});
+        expect(mockedGet).toHaveBeenCalledWith(nextPath, filters);
     });
 });

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/categorySlice.test.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/categorySlice.test.ts
@@ -47,7 +47,7 @@ describe("getCategories thunk", () => {
         await store.dispatch(getCategories());
 
         await waitFor(() => {
-            expect(mockedGet).toHaveBeenCalledWith("/api/hardware/categories/");
+            expect(mockedGet).toHaveBeenCalledWith("/api/hardware/categories/", {});
             expect(categorySelectors.selectIds(store.getState())).toEqual(
                 mockCategories.map(({ id }) => id)
             );

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/categorySlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/categorySlice.ts
@@ -7,7 +7,7 @@ import {
 import { RootState, AppDispatch } from "slices/store";
 
 import { APIListResponse, Category } from "api/types";
-import { get, stripHostname } from "api/api";
+import { get, stripHostname, stripHostnameReturnFilters } from "api/api";
 import { displaySnackbar } from "slices/ui/uiSlice";
 
 interface CategoryExtraState {
@@ -43,11 +43,16 @@ export const getCategories = createAsyncThunk<
         let data: APIListResponse<Category> | undefined = undefined;
 
         let path: string = "/api/hardware/categories/";
+        let params: { [key: string]: any } = {};
 
         do {
-            path = data?.next ? stripHostname(data.next) : path;
-            const response = await get<APIListResponse<Category>>(path);
+            const response = await get<APIListResponse<Category>>(path, params);
             data = response.data;
+            if (data?.next) {
+                const nextURLData = stripHostnameReturnFilters(data.next);
+                path = nextURLData.path;
+                params = nextURLData.filters ?? {};
+            }
             categories.push(...data.results);
         } while (data?.next);
 


### PR DESCRIPTION
## Overview

- Resolves #IEEE-128
- updated getCategories thunk to exhaustively get pages of categories successfully


## Unit Tests Created

- updated categorySlice.test.ts 


## Steps to QA

- in hackathon_site/settings/__init__.py set PAGE_SIZE (line 197) to something small, so it forces multiple category pages to load
- go to /inventory on hardware signout site
- categories should load in filters section without a problem

