### PR TITLE
IEEE-122: added export resource to custom user model

### DIFF
--- a/hackathon_site/event/admin.py
+++ b/hackathon_site/event/admin.py
@@ -9,6 +9,7 @@ from hardware.admin import OrderInline
 
 admin.site.unregister(User)
 
+
 class UserResource(resources.ModelResource):
     class Meta:
         model = User
@@ -23,13 +24,24 @@ class UserResource(resources.ModelResource):
         export_order = tuple(fields)
 
     def get_export_headers(self):
-        export_headers = ["First Name", "Last Name", "Email", "Account Confirmed", "Application ID", "Review Status"]
+        export_headers = [
+            "First Name",
+            "Last Name",
+            "Email",
+            "Account Confirmed",
+            "Application ID",
+            "Review Status",
+        ]
         return export_headers
 
 
 @admin.register(User)
 class EnhancedUser(ExportMixin, UserAdmin):
-    list_display = UserAdmin.list_display + ("is_active", "get_application_status", "get_review_status")
+    list_display = UserAdmin.list_display + (
+        "is_active",
+        "get_application_status",
+        "get_review_status",
+    )
     resource_class = UserResource
 
     def get_application_status(self, obj):
@@ -43,10 +55,19 @@ class EnhancedUser(ExportMixin, UserAdmin):
     get_review_status.short_description = "Review Status"
 
     def get_queryset(self, request):
-        return super().get_queryset(request).select_related("application", "application__review")
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("application", "application__review")
+        )
 
     def get_export_queryset(self, request):
-        return super().get_queryset(request).select_related("application", "application__review")
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("application", "application__review")
+        )
+
 
 @admin.register(EventTeam)
 class EventTeamAdmin(admin.ModelAdmin):

--- a/hackathon_site/event/admin.py
+++ b/hackathon_site/event/admin.py
@@ -1,9 +1,38 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
 from django.db.models import Count
+from import_export import resources
+from import_export.admin import ExportMixin
 
-from event.models import Profile, Team as EventTeam
+from event.models import Profile, Team as EventTeam, User
 from hardware.admin import OrderInline
 
+admin.site.unregister(User)
+
+class UserResource(resources.ModelResource):
+    class Meta:
+        model = User
+        fields = (
+            "first_name",
+            "last_name",
+            "email",
+            "is_active",
+        )
+        export_order = tuple(fields)
+
+    def get_export_headers(self):
+        export_headers = [
+            "First Name",
+            "Last Name",
+            "Email",
+            "Account Confirmed"
+        ]
+        return export_headers
+
+@admin.register(User)
+class EnhancedUser(ExportMixin, UserAdmin):
+    resource_class = UserResource
+    list_display = UserAdmin.list_display + ('is_active',)
 
 @admin.register(EventTeam)
 class EventTeamAdmin(admin.ModelAdmin):

--- a/hackathon_site/event/admin.py
+++ b/hackathon_site/event/admin.py
@@ -9,6 +9,7 @@ from hardware.admin import OrderInline
 
 admin.site.unregister(User)
 
+
 class UserResource(resources.ModelResource):
     class Meta:
         model = User
@@ -21,18 +22,15 @@ class UserResource(resources.ModelResource):
         export_order = tuple(fields)
 
     def get_export_headers(self):
-        export_headers = [
-            "First Name",
-            "Last Name",
-            "Email",
-            "Account Confirmed"
-        ]
+        export_headers = ["First Name", "Last Name", "Email", "Account Confirmed"]
         return export_headers
+
 
 @admin.register(User)
 class EnhancedUser(ExportMixin, UserAdmin):
     resource_class = UserResource
-    list_display = UserAdmin.list_display + ('is_active',)
+    list_display = UserAdmin.list_display + ("is_active",)
+
 
 @admin.register(EventTeam)
 class EventTeamAdmin(admin.ModelAdmin):


### PR DESCRIPTION
## Overview

- Resolves #IEEE-122
- made new custom user model
- added export resource to user model

<img width="750" alt="image" src="https://user-images.githubusercontent.com/20618460/159189910-ed5246a6-fd43-4cce-ab1a-1331c0c37013.png">

## Unit Tests Created

- no tests for admin site :///


## Steps to QA

- Have a bunch of users
- go to the admin site
- you should see the user's active status, application status ("Applied" if you've applied or a dash if you haven't) and review status (dash if not reviewed yet) immediately in the table of users
- there should be an export button for all users, click that and it should export the right users with the right info to whatever file you want (please verify this)
