### PR TITLE
IEEE-152-re-fetch-hardware-when-product-overview-loads

### DIFF
--- a/hackathon_site/dashboard/frontend/src/components/dashboard/ItemTable/ItemTable.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/dashboard/ItemTable/ItemTable.tsx
@@ -21,13 +21,16 @@ import {
     isCheckedOutTableVisibleSelector,
     isPendingTableVisibleSelector,
     isReturnedTableVisibleSelector,
-    setProductOverviewItem,
+    openProductOverview,
     toggleCheckedOutTable,
     togglePendingTable,
     toggleReturnedTable,
 } from "slices/ui/uiSlice";
-import { Hardware, OrderStatus } from "api/types";
-import { hardwareSelectors } from "slices/hardware/hardwareSlice";
+import { OrderStatus } from "api/types";
+import {
+    getUpdatedHardwareDetails,
+    hardwareSelectors,
+} from "slices/hardware/hardwareSlice";
 import hardwareImagePlaceholder from "assets/images/placeholders/no-hardware-image.svg";
 import {
     checkedOutOrdersSelector,
@@ -78,8 +81,10 @@ export const CheckedOutTable = () =>
         const isVisible = useSelector(isCheckedOutTableVisibleSelector);
         const fetchOrdersError = useSelector(orderErrorSelector);
         const toggleVisibility = () => dispatch(toggleCheckedOutTable());
-        const openProductOverview = (hardwareItem: Hardware | undefined) =>
-            hardwareItem ? dispatch(setProductOverviewItem(hardwareItem)) : null;
+        const openProductOverviewPanel = (hardwareId: number) => {
+            dispatch(getUpdatedHardwareDetails(hardwareId));
+            dispatch(openProductOverview());
+        };
 
         return (
             <Container
@@ -188,11 +193,11 @@ export const CheckedOutTable = () =>
                                                                 color="inherit"
                                                                 aria-label="Info"
                                                                 data-testid="info-button"
-                                                                onClick={() => {
-                                                                    openProductOverview(
-                                                                        hardware[row.id]
-                                                                    );
-                                                                }}
+                                                                onClick={() =>
+                                                                    openProductOverviewPanel(
+                                                                        row.id
+                                                                    )
+                                                                }
                                                             >
                                                                 <Info />
                                                             </IconButton>

--- a/hackathon_site/dashboard/frontend/src/components/inventory/InventoryGrid/InventoryGrid.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/InventoryGrid/InventoryGrid.tsx
@@ -3,19 +3,24 @@ import Grid from "@material-ui/core/Grid";
 import styles from "pages/Inventory/Inventory.module.scss";
 import Item from "components/inventory/Item/Item";
 import { useDispatch, useSelector } from "react-redux";
-import { hardwareSelectors, isLoadingSelector } from "slices/hardware/hardwareSlice";
+import {
+    getUpdatedHardwareDetails,
+    hardwareSelectors,
+    isLoadingSelector,
+} from "slices/hardware/hardwareSlice";
 import { LinearProgress } from "@material-ui/core";
-import { setProductOverviewItem } from "slices/ui/uiSlice";
-import { Hardware } from "api/types";
 import hardwareImagePlaceholder from "assets/images/placeholders/no-hardware-image.svg";
+import { openProductOverview } from "slices/ui/uiSlice";
 
 export const InventoryGrid = () => {
     const dispatch = useDispatch();
     const items = useSelector(hardwareSelectors.selectAll);
     const isLoading = useSelector(isLoadingSelector);
 
-    const openProductOverview = (hardware: Hardware) =>
-        dispatch(setProductOverviewItem(hardware));
+    const openProductOverviewPanel = (hardwareId: number) => {
+        dispatch(getUpdatedHardwareDetails(hardwareId));
+        dispatch(openProductOverview());
+    };
 
     return isLoading ? (
         <LinearProgress
@@ -35,7 +40,7 @@ export const InventoryGrid = () => {
                         className={styles.Item}
                         key={item.id}
                         item
-                        onClick={() => openProductOverview(item)}
+                        onClick={() => openProductOverviewPanel(item.id)}
                     >
                         <Item
                             image={item.picture ?? hardwareImagePlaceholder}

--- a/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.test.tsx
@@ -10,6 +10,7 @@ import {
     when,
     makeMockApiResponse,
 } from "testing/utils";
+import { makeStore } from "slices/store";
 import { cartSelectors } from "slices/hardware/cartSlice";
 import { SnackbarProvider } from "notistack";
 import SnackbarNotifier from "components/general/SnackbarNotifier/SnackbarNotifier";
@@ -148,8 +149,13 @@ describe("<ProductOverview />", () => {
         expect(getByText(minConstraint)).toBeInTheDocument();
     });
 
-    it("displays error message when unable to get hardware", () => {
+    it("displays error message when unable to get hardware", async () => {
+        const apiResponse = makeMockApiResponse({}, 500);
+
+        when(mockedGet).mockResolvedValue(apiResponse);
+
         const store = makeStoreWithEntities({
+            hardware: mockHardware,
             hardwareState: {
                 isUpdateDetailsLoading: false,
             },
@@ -164,11 +170,15 @@ describe("<ProductOverview />", () => {
             store,
         });
 
-        expect(
-            getByText(
-                "Unable to display hardware. Please refresh the page and try again."
-            )
-        ).toBeInTheDocument();
+        store.dispatch(getUpdatedHardwareDetails(1));
+
+        await waitFor(() => {
+            expect(
+                getByText(
+                    "Unable to display hardware. Please refresh the page and try again."
+                )
+            ).toBeInTheDocument();
+        });
     });
 
     test("Add to Cart button adds hardware to cart store", async () => {

--- a/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.test.tsx
@@ -150,9 +150,14 @@ describe("<ProductOverview />", () => {
     });
 
     it("displays error message when unable to get hardware", async () => {
-        const apiResponse = makeMockApiResponse({}, 500);
+        const failureResponse = {
+            response: {
+                status: 500,
+                message: "Something went wrong",
+            },
+        };
 
-        when(mockedGet).mockResolvedValue(apiResponse);
+        mockedGet.mockRejectedValue(failureResponse);
 
         const store = makeStoreWithEntities({
             hardware: mockHardware,

--- a/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import Typography from "@material-ui/core/Typography";
 import Button from "@material-ui/core/Button";
 import MenuItem from "@material-ui/core/MenuItem";
@@ -15,19 +15,21 @@ import { Formik, FormikValues } from "formik";
 
 import styles from "./ProductOverview.module.scss";
 import {
+    closeProductOverview,
     displaySnackbar,
-    hardwareBeingViewedSelector,
     isProductOverviewVisibleSelector,
-    removeProductOverviewItem,
 } from "slices/ui/uiSlice";
 import { useDispatch, useSelector } from "react-redux";
 import { selectCategoriesByIds } from "slices/hardware/categorySlice";
 import { RootState } from "slices/store";
 import { addToCart, cartSelectors } from "slices/hardware/cartSlice";
-import { isUpdateDetailsLoading } from "slices/hardware/hardwareSlice";
+import {
+    hardwareInProductOverviewSelector,
+    isUpdateDetailsLoading,
+    removeProductOverviewItem,
+} from "slices/hardware/hardwareSlice";
 import { Category } from "api/types";
 import hardwareImagePlaceholder from "assets/images/placeholders/no-hardware-image.svg";
-import { getUpdatedHardwareDetails } from "slices/hardware/hardwareSlice";
 
 export const ERROR_MESSAGES = {
     quantityMissing: "Quantity is required",
@@ -292,19 +294,15 @@ export const ProductOverview = ({
     const isLoading = useSelector(isUpdateDetailsLoading);
 
     const dispatch = useDispatch();
-    const closeProductOverview = () => dispatch(removeProductOverviewItem());
+    const closeProductOverviewPanel = () => {
+        dispatch(closeProductOverview());
+        dispatch(removeProductOverviewItem());
+    };
 
     const isProductOverviewVisible: boolean = useSelector(
         isProductOverviewVisibleSelector
     );
-    const hardware = useSelector(hardwareBeingViewedSelector);
-
-    useEffect(() => {
-        if (hardware) {
-            dispatch(getUpdatedHardwareDetails(hardware.id));
-        }
-    }, [dispatch, hardware]);
-
+    const hardware = useSelector(hardwareInProductOverviewSelector);
     const categories = useSelector((state: RootState) =>
         selectCategoriesByIds(state, hardware?.categories || [])
     );
@@ -334,7 +332,7 @@ export const ProductOverview = ({
         <SideSheetRight
             title="Product Overview"
             isVisible={isProductOverviewVisible}
-            handleClose={closeProductOverview}
+            handleClose={closeProductOverviewPanel}
         >
             {isLoading ? (
                 <CircularProgress

--- a/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.tsx
@@ -7,6 +7,7 @@ import Select from "@material-ui/core/Select";
 import LaunchIcon from "@material-ui/icons/Launch";
 import InputLabel from "@material-ui/core/InputLabel";
 import Chip from "@material-ui/core/Chip";
+import CircularProgress from "@material-ui/core/CircularProgress";
 import SideSheetRight from "components/general/SideSheetRight/SideSheetRight";
 
 import * as Yup from "yup";
@@ -23,6 +24,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { selectCategoriesByIds } from "slices/hardware/categorySlice";
 import { RootState } from "slices/store";
 import { addToCart, cartSelectors } from "slices/hardware/cartSlice";
+import { isUpdateDetailsLoading } from "slices/hardware/hardwareSlice";
 import { Category } from "api/types";
 import hardwareImagePlaceholder from "assets/images/placeholders/no-hardware-image.svg";
 import { getUpdatedHardwareDetails } from "slices/hardware/hardwareSlice";
@@ -287,6 +289,8 @@ export const ProductOverview = ({
     let maxPerTeam: number | null = null;
     let constraints: string[] = [];
 
+    const isLoading = useSelector(isUpdateDetailsLoading);
+
     const dispatch = useDispatch();
     const closeProductOverview = () => dispatch(removeProductOverviewItem());
 
@@ -332,7 +336,16 @@ export const ProductOverview = ({
             isVisible={isProductOverviewVisible}
             handleClose={closeProductOverview}
         >
-            {hardware ? (
+            {isLoading ? (
+                <CircularProgress
+                    data-testid="circular-progress"
+                    style={{
+                        position: "absolute",
+                        left: "50%",
+                        top: "50%",
+                    }}
+                />
+            ) : hardware ? (
                 <div className={styles.productOverview}>
                     <div className={styles.productOverviewDiv}>
                         <MainSection

--- a/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Typography from "@material-ui/core/Typography";
 import Button from "@material-ui/core/Button";
 import MenuItem from "@material-ui/core/MenuItem";
@@ -295,9 +295,11 @@ export const ProductOverview = ({
     );
     const hardware = useSelector(hardwareBeingViewedSelector);
 
-    if (hardware) {
-        dispatch(getUpdatedHardwareDetails());
-    }
+    useEffect(() => {
+        if (hardware) {
+            dispatch(getUpdatedHardwareDetails(hardware.id));
+        }
+    }, [dispatch, hardware]);
 
     const categories = useSelector((state: RootState) =>
         selectCategoriesByIds(state, hardware?.categories || [])

--- a/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.tsx
@@ -25,6 +25,7 @@ import { RootState } from "slices/store";
 import { addToCart, cartSelectors } from "slices/hardware/cartSlice";
 import { Category } from "api/types";
 import hardwareImagePlaceholder from "assets/images/placeholders/no-hardware-image.svg";
+import { getUpdatedHardwareDetails } from "slices/hardware/hardwareSlice";
 
 export const ERROR_MESSAGES = {
     quantityMissing: "Quantity is required",
@@ -293,6 +294,11 @@ export const ProductOverview = ({
         isProductOverviewVisibleSelector
     );
     const hardware = useSelector(hardwareBeingViewedSelector);
+
+    if (hardware) {
+        dispatch(getUpdatedHardwareDetails());
+    }
+
     const categories = useSelector((state: RootState) =>
         selectCategoriesByIds(state, hardware?.categories || [])
     );

--- a/hackathon_site/dashboard/frontend/src/pages/Dashboard/Dashboard.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Dashboard/Dashboard.test.tsx
@@ -10,6 +10,7 @@ import {
     within,
     promiseResolveWithDelay,
     makeStoreWithEntities,
+    makeMockApiResponse,
 } from "testing/utils";
 import {
     cardItems,
@@ -21,7 +22,7 @@ import {
 } from "testing/mockData";
 import { get } from "api/api";
 import { AxiosResponse } from "axios";
-import { Order, Team } from "api/types";
+import { Hardware, Order, Team } from "api/types";
 
 jest.mock("api/api", () => ({
     ...jest.requireActual("api/api"),
@@ -63,9 +64,26 @@ describe("Dashboard Page", () => {
         });
         // TODO: add check for returned items and broken items when those are ready
     });
+
     it("Opens Product Overview with the correct hardware information", async () => {
+        const hardwareDetailUri = "/api/hardware/hardware/1/";
+        const newHardwareData: Hardware = {
+            id: mockCheckedOutOrders[0].items[0].hardware_id,
+            name: "Randome hardware",
+            model_number: "90",
+            manufacturer: "Tesla",
+            datasheet: "",
+            quantity_available: 5,
+            max_per_team: 6,
+            picture: "https://example.com/datasheet",
+            categories: [2],
+            quantity_remaining: 10,
+            notes: "notes on temp",
+        };
+
         const hardwareApiResponse = makeMockApiListResponse(mockHardware);
         const categoryApiResponse = makeMockApiListResponse(mockCategories);
+        const hardwareDetailApiResponse = makeMockApiResponse(newHardwareData);
         const hardware_ids = [1, 2, 3, 4, 10];
 
         mockOrderAPI();
@@ -75,37 +93,46 @@ describe("Dashboard Page", () => {
         when(mockedGet)
             .calledWith(categoriesUri, {})
             .mockResolvedValue(categoryApiResponse);
+        when(mockedGet)
+            .calledWith(hardwareDetailUri)
+            .mockResolvedValue(hardwareDetailApiResponse);
 
         const { getByTestId, getByText } = render(<Dashboard />);
 
-        const hardware = mockHardware.find(
-            ({ id }) => id === mockCheckedOutOrders[0].items[0].hardware_id
-        );
         const category = mockCategories.find(
-            ({ id }) => id === hardware?.categories[0]
+            ({ id }) => id === newHardwareData?.categories[0]
         );
 
-        if (hardware && category) {
+        if (category) {
+            await waitFor(() => {
+                expect(get).toHaveBeenNthCalledWith(1, teamUri);
+                expect(get).toHaveBeenNthCalledWith(2, categoriesUri, {});
+                expect(get).toHaveBeenNthCalledWith(3, ordersUri);
+                expect(get).toHaveBeenNthCalledWith(4, hardwareUri, { hardware_ids });
+            });
             await waitFor(() => {
                 const infoButton = within(
                     getByTestId(
-                        `checked-out-hardware-${hardware.id}-${mockCheckedOutOrders[0].id}`
+                        `checked-out-hardware-${newHardwareData.id}-${mockCheckedOutOrders[0].id}`
                     )
                 ).getByTestId("info-button");
                 fireEvent.click(infoButton);
+            });
+            await waitFor(() => {
+                expect(get).toHaveBeenNthCalledWith(5, hardwareDetailUri);
                 expect(getByText("Product Overview")).toBeVisible();
                 expect(
-                    getByText(`- Max ${hardware.max_per_team} of this item`)
+                    getByText(`- Max ${newHardwareData.max_per_team} of this item`)
                 ).toBeInTheDocument();
                 expect(
                     getByText(
-                        `- Max ${mockCategories[0].max_per_team} of items under category ${mockCategories[0].name}`
+                        `- Max ${category.max_per_team} of items under category ${category.name}`
                     )
                 ).toBeInTheDocument();
-                expect(getByText(hardware.model_number)).toBeInTheDocument();
-                expect(getByText(hardware.manufacturer)).toBeInTheDocument();
-                if (hardware.notes)
-                    expect(getByText(hardware.notes)).toBeInTheDocument();
+                expect(getByText(newHardwareData.model_number)).toBeInTheDocument();
+                expect(getByText(newHardwareData.manufacturer)).toBeInTheDocument();
+                if (newHardwareData.notes)
+                    expect(getByText(newHardwareData.notes)).toBeInTheDocument();
             });
         }
     });

--- a/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.test.tsx
@@ -7,6 +7,7 @@ import {
     when,
     fireEvent,
     promiseResolveWithDelay,
+    makeMockApiResponse,
 } from "testing/utils";
 
 import Inventory from "pages/Inventory/Inventory";
@@ -134,8 +135,24 @@ describe("Inventory Page", () => {
     });
 
     it("Shows product overview when hardware item is clicked", async () => {
+        const hardwareDetailUri = "/api/hardware/hardware/1/";
+        const newHardwareData = {
+            ...mockHardware[0],
+            name: "Randome hardware",
+            model_number: "90",
+            manufacturer: "Tesla",
+            datasheet: "",
+            quantity_available: 5,
+            max_per_team: 6,
+            picture: "https://example.com/datasheet",
+            categories: [2],
+            quantity_remaining: 10,
+            notes: "notes on temp",
+        };
+
         const hardwareApiResponse = makeMockApiListResponse(mockHardware);
         const categoryApiResponse = makeMockApiListResponse(mockCategories);
+        const hardwareDetailApiResponse = makeMockApiResponse(newHardwareData);
 
         when(mockedGet)
             .calledWith(hardwareUri, {})
@@ -143,6 +160,9 @@ describe("Inventory Page", () => {
         when(mockedGet)
             .calledWith(categoriesUri, {})
             .mockResolvedValue(categoryApiResponse);
+        when(mockedGet)
+            .calledWith(hardwareDetailUri)
+            .mockResolvedValue(hardwareDetailApiResponse);
 
         const { getByText } = render(<Inventory />);
 
@@ -154,19 +174,21 @@ describe("Inventory Page", () => {
 
         fireEvent.click(getByText(mockHardware[0].name));
 
-        expect(getByText("Product Overview")).toBeVisible();
-        expect(
-            getByText(`- Max ${mockHardware[0].max_per_team} of this item`)
-        ).toBeInTheDocument();
-        expect(
-            getByText(
-                `- Max ${mockCategories[0].max_per_team} of items under category ${mockCategories[0].name}`
-            )
-        ).toBeInTheDocument();
-        expect(getByText(mockHardware[0].model_number)).toBeInTheDocument();
-        expect(getByText(mockHardware[0].manufacturer)).toBeInTheDocument();
-        if (mockHardware[0].notes)
-            expect(getByText(mockHardware[0].notes)).toBeInTheDocument();
+        await waitFor(() => {
+            expect(get).toHaveBeenNthCalledWith(3, hardwareDetailUri);
+            expect(getByText("Product Overview")).toBeVisible();
+            expect(
+                getByText(`- Max ${newHardwareData.max_per_team} of this item`)
+            ).toBeInTheDocument();
+            expect(
+                getByText(
+                    `- Max ${mockCategories[1].max_per_team} of items under category ${mockCategories[1].name}`
+                )
+            ).toBeInTheDocument();
+            expect(getByText(newHardwareData.model_number)).toBeInTheDocument();
+            expect(getByText(newHardwareData.manufacturer)).toBeInTheDocument();
+            expect(getByText(newHardwareData.notes)).toBeInTheDocument();
+        });
     });
 
     it("Loads more hardware", async () => {

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/hardwareSlice.test.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/hardwareSlice.test.ts
@@ -256,23 +256,4 @@ describe("getUpdatedHardwareDetails thunk", () => {
             })
         );
     });
-
-    it("Updates the store on API failure", async () => {
-        const failureResponse = {
-            response: {
-                status: 500,
-                message: "Something went wrong",
-            },
-        };
-
-        mockedGet.mockRejectedValue(failureResponse);
-
-        const store = makeStore();
-        await store.dispatch(getUpdatedHardwareDetails(1));
-
-        expect(store.getState()[hardwareReducerName]).toHaveProperty(
-            "error",
-            failureResponse.response.message
-        );
-    });
 });

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/hardwareSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/hardwareSlice.ts
@@ -113,7 +113,6 @@ export const getUpdatedHardwareDetails = createAsyncThunk<
     `${hardwareReducerName}/getHardwareDetails`,
     async (hardware_id, { dispatch, getState, rejectWithValue }) => {
         try {
-            console.log(hardware_id);
             const response = await get<Hardware>(
                 `/api/hardware/hardware/${hardware_id}/`
             );
@@ -264,6 +263,11 @@ export const isLoadingSelector = createSelector(
 export const isMoreLoadingSelector = createSelector(
     [hardwareSliceSelector],
     (hardwareSlice) => hardwareSlice.isMoreLoading
+);
+
+export const isUpdateDetailsLoading = createSelector(
+    [hardwareSliceSelector],
+    (hardwareSlice) => hardwareSlice.isUpdateDetailsLoading
 );
 
 export const hardwareCountSelector = createSelector(

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/hardwareSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/hardwareSlice.ts
@@ -228,13 +228,11 @@ const hardwareSlice = createSlice({
 
         builder.addCase(getUpdatedHardwareDetails.pending, (state) => {
             state.isUpdateDetailsLoading = true;
-            state.error = null;
         });
 
         builder.addCase(getUpdatedHardwareDetails.fulfilled, (state, { payload }) => {
             if (payload) {
                 state.isUpdateDetailsLoading = false;
-                state.error = null;
                 state.hardwareIdInProductOverview = payload.id;
                 hardwareAdapter.updateOne(state, {
                     id: payload.id,
@@ -245,7 +243,6 @@ const hardwareSlice = createSlice({
 
         builder.addCase(getUpdatedHardwareDetails.rejected, (state, { payload }) => {
             state.isUpdateDetailsLoading = false;
-            state.error = payload?.message || "Something went wrong";
         });
     },
 });

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/hardwareSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/hardwareSlice.ts
@@ -4,14 +4,12 @@ import {
     PayloadAction,
     createSelector,
     createAsyncThunk,
-    Update,
 } from "@reduxjs/toolkit";
 import { RootState, AppDispatch } from "slices/store";
 
 import { APIListResponse, Hardware, HardwareFilters } from "api/types";
 import { get, stripHostnameReturnFilters } from "api/api";
 import { displaySnackbar } from "slices/ui/uiSlice";
-import { number } from "yup";
 
 interface HardwareExtraState {
     isUpdateDetailsLoading: boolean;
@@ -21,6 +19,7 @@ interface HardwareExtraState {
     next: string | null;
     filters: HardwareFilters;
     count: number;
+    hardwareIdInProductOverview: number | null;
 }
 
 const extraState: HardwareExtraState = {
@@ -31,6 +30,7 @@ const extraState: HardwareExtraState = {
     next: null,
     filters: {},
     count: 0,
+    hardwareIdInProductOverview: null,
 };
 
 export const hardwareReducerName = "hardware";
@@ -173,6 +173,10 @@ const hardwareSlice = createSlice({
                 state.filters.search = search;
             }
         },
+
+        removeProductOverviewItem: (state: HardwareState) => {
+            state.hardwareIdInProductOverview = null;
+        },
     },
     extraReducers: (builder) => {
         builder.addCase(getHardwareWithFilters.pending, (state) => {
@@ -231,6 +235,7 @@ const hardwareSlice = createSlice({
             if (payload) {
                 state.isUpdateDetailsLoading = false;
                 state.error = null;
+                state.hardwareIdInProductOverview = payload.id;
                 hardwareAdapter.updateOne(state, {
                     id: payload.id,
                     changes: payload,
@@ -248,7 +253,7 @@ const hardwareSlice = createSlice({
 export const { actions, reducer } = hardwareSlice;
 export default reducer;
 
-export const { setFilters, clearFilters } = actions;
+export const { setFilters, clearFilters, removeProductOverviewItem } = actions;
 
 // Selectors
 export const hardwareSliceSelector = (state: RootState) => state[hardwareReducerName];
@@ -288,4 +293,12 @@ export const hardwareNextSelector = createSelector(
 export const selectHardwareByIds = createSelector(
     [hardwareSelectors.selectEntities, (state: RootState, ids: number[]) => ids],
     (entities, ids) => ids.map((id) => entities?.[id])
+);
+
+export const hardwareInProductOverviewSelector = createSelector(
+    [hardwareSelectors.selectEntities, hardwareSliceSelector],
+    (entities, hardwareSlice) =>
+        hardwareSlice.hardwareIdInProductOverview
+            ? entities[hardwareSlice.hardwareIdInProductOverview]
+            : null
 );

--- a/hackathon_site/dashboard/frontend/src/slices/ui/uiSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/ui/uiSlice.ts
@@ -1,5 +1,4 @@
-import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { Hardware } from "api/types";
+import { createSelector, createSlice } from "@reduxjs/toolkit";
 import { RootState } from "../store";
 
 // Slice
@@ -10,7 +9,6 @@ interface UIInitialState {
         isPendingTableVisible: boolean;
     };
     inventory: {
-        hardwareItemBeingViewed: Hardware | null;
         isProductOverviewVisible: boolean;
     };
     snackbars: {
@@ -29,7 +27,6 @@ export const initialState: UIInitialState = {
         isPendingTableVisible: true,
     },
     inventory: {
-        hardwareItemBeingViewed: null,
         isProductOverviewVisible: false,
     },
     snackbars: [],
@@ -51,15 +48,10 @@ const uiSlice = createSlice({
             state.dashboard.isPendingTableVisible =
                 !state.dashboard.isPendingTableVisible;
         },
-        setProductOverviewItem: (
-            state: UIState,
-            { payload }: PayloadAction<Hardware>
-        ) => {
-            state.inventory.hardwareItemBeingViewed = payload;
+        openProductOverview: (state: UIState) => {
             state.inventory.isProductOverviewVisible = true;
         },
-        removeProductOverviewItem: (state: UIState) => {
-            state.inventory.hardwareItemBeingViewed = null;
+        closeProductOverview: (state: UIState) => {
             state.inventory.isProductOverviewVisible = false;
         },
         displaySnackbar: (state: UIState, { payload: { message, options = {} } }) => {
@@ -100,8 +92,8 @@ export const {
     toggleCheckedOutTable,
     toggleReturnedTable,
     togglePendingTable,
-    setProductOverviewItem,
-    removeProductOverviewItem,
+    openProductOverview,
+    closeProductOverview,
     displaySnackbar,
     dismissSnackbar,
     removeSnackbar,
@@ -125,10 +117,6 @@ export const isPendingTableVisibleSelector = createSelector(
 export const snackbarSelector = createSelector(
     [uiSliceSelector],
     (uiSlice) => uiSlice.snackbars
-);
-export const hardwareBeingViewedSelector = createSelector(
-    [uiSliceSelector],
-    (uiSlice) => uiSlice.inventory.hardwareItemBeingViewed
 );
 export const isProductOverviewVisibleSelector = createSelector(
     [uiSliceSelector],

--- a/hackathon_site/dashboard/frontend/src/testing/utils.tsx
+++ b/hackathon_site/dashboard/frontend/src/testing/utils.tsx
@@ -142,9 +142,7 @@ export const makeStoreWithEntities = (entities: StoreEntities) => {
         }
 
         preloadedState[hardwareReducerName] = hardwareState;
-    }
-
-    if (entities.hardwareState) {
+    } else if (entities.hardwareState) {
         preloadedState[hardwareReducerName] = {
             ...hardwareInitialState,
             ...entities.hardwareState,

--- a/hackathon_site/dashboard/frontend/src/testing/utils.tsx
+++ b/hackathon_site/dashboard/frontend/src/testing/utils.tsx
@@ -111,6 +111,7 @@ export * from "jest-when";
 
 export interface StoreEntities {
     hardware?: Hardware[];
+    hardwareState?: Partial<HardwareState>;
     categories?: Category[];
     ui?: DeepPartial<UIState>;
     cartItems?: CartItem[];
@@ -123,6 +124,7 @@ export const makeStoreWithEntities = (entities: StoreEntities) => {
     if (entities.hardware) {
         const hardwareState: HardwareState = {
             ...hardwareInitialState,
+            ...entities.hardwareState,
             ids: [],
             entities: {},
         };
@@ -133,6 +135,13 @@ export const makeStoreWithEntities = (entities: StoreEntities) => {
         }
 
         preloadedState[hardwareReducerName] = hardwareState;
+    }
+
+    if (entities.hardwareState) {
+        preloadedState[hardwareReducerName] = {
+            ...hardwareInitialState,
+            ...entities.hardwareState,
+        };
     }
 
     if (entities.categories) {


### PR DESCRIPTION
## Overview

- Resolves #<[IEEE-152](https://ieeeuoft.atlassian.net/browse/IEEE-152)>
- Once the user opens Product Overview Sidebar, hardware details are re-fetched to show the most up to date data
- Created a redux thunk for re-fetching the data
- Created a Loader for the Product Overview component


## Unit Tests Created

- Tested the thunk getUpdatedHardwareDetails in the hardwareSlice.test.tsx for API operations
- Tested the ProductOverview component for displaying up to date data (Issue: failing testcases)



## Steps to QA
- Navigate to Inventory
- Click on an inventory item
- Should see the most up to date data

