### PR TITLE
Ieee 152 move hardware in view to hardware slice

### DIFF
--- a/hackathon_site/dashboard/frontend/src/components/dashboard/ItemTable/ItemTable.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/dashboard/ItemTable/ItemTable.tsx
@@ -21,13 +21,16 @@ import {
     isCheckedOutTableVisibleSelector,
     isPendingTableVisibleSelector,
     isReturnedTableVisibleSelector,
-    setProductOverviewItem,
+    openProductOverview,
     toggleCheckedOutTable,
     togglePendingTable,
     toggleReturnedTable,
 } from "slices/ui/uiSlice";
-import { Hardware, ItemsInOrder, Order, OrderStatus } from "api/types";
-import { hardwareSelectors } from "slices/hardware/hardwareSlice";
+import { ItemsInOrder, Order, OrderStatus } from "api/types";
+import {
+    getUpdatedHardwareDetails,
+    hardwareSelectors,
+} from "slices/hardware/hardwareSlice";
 import hardwareImagePlaceholder from "assets/images/placeholders/no-hardware-image.svg";
 
 export const ChipStatus = ({ status }: { status: OrderStatus | "Error" }) => {
@@ -88,10 +91,9 @@ TableProps) => {
     const hardware = useSelector(hardwareSelectors.selectEntities);
     const isVisible = useSelector(isCheckedOutTableVisibleSelector);
     const toggleVisibility = () => dispatch(toggleCheckedOutTable());
-    const openProductOverview = (hardwareItem: Hardware | undefined) => {
-        if (hardwareItem) {
-            dispatch(setProductOverviewItem(hardwareItem));
-        }
+    const openProductOverviewPanel = (hardwareId: number) => {
+        dispatch(getUpdatedHardwareDetails(hardwareId));
+        dispatch(openProductOverview());
     };
 
     const checkedOutOrders: OrderInTable[] = [];
@@ -219,8 +221,8 @@ TableProps) => {
                                                             aria-label="Info"
                                                             data-testid="info-button"
                                                             onClick={() => {
-                                                                openProductOverview(
-                                                                    hardware[row.id]
+                                                                openProductOverviewPanel(
+                                                                    row.id
                                                                 );
                                                             }}
                                                         >

--- a/hackathon_site/dashboard/frontend/src/components/dashboard/ItemTable/ItemTable.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/dashboard/ItemTable/ItemTable.tsx
@@ -26,11 +26,10 @@ import {
     togglePendingTable,
     toggleReturnedTable,
 } from "slices/ui/uiSlice";
-import { ItemsInOrder, Order, OrderStatus } from "api/types";
+import { OrderStatus } from "api/types";
 import {
     getUpdatedHardwareDetails,
     hardwareSelectors,
-    setProductOverviewHardwareId,
 } from "slices/hardware/hardwareSlice";
 import hardwareImagePlaceholder from "assets/images/placeholders/no-hardware-image.svg";
 import {

--- a/hackathon_site/dashboard/frontend/src/components/inventory/InventoryGrid/InventoryGrid.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/InventoryGrid/InventoryGrid.tsx
@@ -3,19 +3,24 @@ import Grid from "@material-ui/core/Grid";
 import styles from "pages/Inventory/Inventory.module.scss";
 import Item from "components/inventory/Item/Item";
 import { useDispatch, useSelector } from "react-redux";
-import { hardwareSelectors, isLoadingSelector } from "slices/hardware/hardwareSlice";
+import {
+    getUpdatedHardwareDetails,
+    hardwareSelectors,
+    isLoadingSelector,
+} from "slices/hardware/hardwareSlice";
 import { LinearProgress } from "@material-ui/core";
-import { setProductOverviewItem } from "slices/ui/uiSlice";
-import { Hardware } from "api/types";
 import hardwareImagePlaceholder from "assets/images/placeholders/no-hardware-image.svg";
+import { openProductOverview } from "slices/ui/uiSlice";
 
 export const InventoryGrid = () => {
     const dispatch = useDispatch();
     const items = useSelector(hardwareSelectors.selectAll);
     const isLoading = useSelector(isLoadingSelector);
 
-    const openProductOverview = (hardware: Hardware) =>
-        dispatch(setProductOverviewItem(hardware));
+    const openProductOverviewPanel = (hardwareId: number) => {
+        dispatch(getUpdatedHardwareDetails(hardwareId));
+        dispatch(openProductOverview());
+    };
 
     return isLoading ? (
         <LinearProgress
@@ -35,7 +40,7 @@ export const InventoryGrid = () => {
                         className={styles.Item}
                         key={item.id}
                         item
-                        onClick={() => openProductOverview(item)}
+                        onClick={() => openProductOverviewPanel(item.id)}
                     >
                         <Item
                             image={item.picture ?? hardwareImagePlaceholder}

--- a/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/inventory/ProductOverview/ProductOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import Typography from "@material-ui/core/Typography";
 import Button from "@material-ui/core/Button";
 import MenuItem from "@material-ui/core/MenuItem";
@@ -15,19 +15,21 @@ import { Formik, FormikValues } from "formik";
 
 import styles from "./ProductOverview.module.scss";
 import {
+    closeProductOverview,
     displaySnackbar,
-    hardwareBeingViewedSelector,
     isProductOverviewVisibleSelector,
-    removeProductOverviewItem,
 } from "slices/ui/uiSlice";
 import { useDispatch, useSelector } from "react-redux";
 import { selectCategoriesByIds } from "slices/hardware/categorySlice";
 import { RootState } from "slices/store";
 import { addToCart, cartSelectors } from "slices/hardware/cartSlice";
-import { isUpdateDetailsLoading } from "slices/hardware/hardwareSlice";
+import {
+    hardwareInProductOverviewSelector,
+    isUpdateDetailsLoading,
+    removeProductOverviewItem,
+} from "slices/hardware/hardwareSlice";
 import { Category } from "api/types";
 import hardwareImagePlaceholder from "assets/images/placeholders/no-hardware-image.svg";
-import { getUpdatedHardwareDetails } from "slices/hardware/hardwareSlice";
 
 export const ERROR_MESSAGES = {
     quantityMissing: "Quantity is required",
@@ -292,19 +294,15 @@ export const ProductOverview = ({
     const isLoading = useSelector(isUpdateDetailsLoading);
 
     const dispatch = useDispatch();
-    const closeProductOverview = () => dispatch(removeProductOverviewItem());
+    const closeProductOverviewPanel = () => {
+        dispatch(closeProductOverview());
+        dispatch(removeProductOverviewItem());
+    };
 
     const isProductOverviewVisible: boolean = useSelector(
         isProductOverviewVisibleSelector
     );
-    const hardware = useSelector(hardwareBeingViewedSelector);
-
-    useEffect(() => {
-        if (hardware) {
-            dispatch(getUpdatedHardwareDetails(hardware.id));
-        }
-    }, [dispatch, hardware]);
-
+    const hardware = useSelector(hardwareInProductOverviewSelector);
     const categories = useSelector((state: RootState) =>
         selectCategoriesByIds(state, hardware?.categories || [])
     );
@@ -334,7 +332,7 @@ export const ProductOverview = ({
         <SideSheetRight
             title="Product Overview"
             isVisible={isProductOverviewVisible}
-            handleClose={closeProductOverview}
+            handleClose={closeProductOverviewPanel}
         >
             {isLoading ? (
                 <CircularProgress

--- a/hackathon_site/dashboard/frontend/src/pages/Dashboard/Dashboard.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Dashboard/Dashboard.test.tsx
@@ -10,6 +10,7 @@ import {
     within,
     promiseResolveWithDelay,
     makeStoreWithEntities,
+    makeMockApiResponse,
 } from "testing/utils";
 import {
     cardItems,
@@ -21,7 +22,7 @@ import {
 } from "testing/mockData";
 import { get } from "api/api";
 import { AxiosResponse } from "axios";
-import { Order, Team } from "api/types";
+import { Hardware, Order, Team } from "api/types";
 
 jest.mock("api/api", () => ({
     ...jest.requireActual("api/api"),
@@ -63,9 +64,26 @@ describe("Dashboard Page", () => {
         });
         // TODO: add check for returned items and broken items when those are ready
     });
+
     it("Opens Product Overview with the correct hardware information", async () => {
+        const hardwareDetailUri = "/api/hardware/hardware/1/";
+        const newHardwareData: Hardware = {
+            id: mockCheckedOutOrders[0].items[0].hardware_id,
+            name: "Randome hardware",
+            model_number: "90",
+            manufacturer: "Tesla",
+            datasheet: "",
+            quantity_available: 5,
+            max_per_team: 6,
+            picture: "https://example.com/datasheet",
+            categories: [2],
+            quantity_remaining: 10,
+            notes: "notes on temp",
+        };
+
         const hardwareApiResponse = makeMockApiListResponse(mockHardware);
         const categoryApiResponse = makeMockApiListResponse(mockCategories);
+        const hardwareDetailApiResponse = makeMockApiResponse(newHardwareData);
         const hardware_ids = [1, 2, 3, 4, 10];
 
         mockOrderAPI();
@@ -75,37 +93,46 @@ describe("Dashboard Page", () => {
         when(mockedGet)
             .calledWith(categoriesUri, {})
             .mockResolvedValue(categoryApiResponse);
+        when(mockedGet)
+            .calledWith(hardwareDetailUri)
+            .mockResolvedValue(hardwareDetailApiResponse);
 
         const { getByTestId, getByText } = render(<Dashboard />);
 
-        const hardware = mockHardware.find(
-            ({ id }) => id === mockCheckedOutOrders[0].items[0].hardware_id
-        );
         const category = mockCategories.find(
-            ({ id }) => id === hardware?.categories[0]
+            ({ id }) => id === newHardwareData?.categories[0]
         );
 
-        if (hardware && category) {
+        if (category) {
+            await waitFor(() => {
+                expect(get).toHaveBeenNthCalledWith(1, teamUri);
+                expect(get).toHaveBeenNthCalledWith(2, categoriesUri, {});
+                expect(get).toHaveBeenNthCalledWith(3, ordersUri);
+                expect(get).toHaveBeenNthCalledWith(4, hardwareUri, { hardware_ids });
+            });
             await waitFor(() => {
                 const infoButton = within(
                     getByTestId(
-                        `checked-out-hardware-${hardware.id}-${mockCheckedOutOrders[0].id}`
+                        `checked-out-hardware-${newHardwareData.id}-${mockCheckedOutOrders[0].id}`
                     )
                 ).getByTestId("info-button");
                 fireEvent.click(infoButton);
+            });
+            await waitFor(() => {
+                expect(get).toHaveBeenNthCalledWith(5, hardwareDetailUri);
                 expect(getByText("Product Overview")).toBeVisible();
                 expect(
-                    getByText(`- Max ${hardware.max_per_team} of this item`)
+                    getByText(`- Max ${newHardwareData.max_per_team} of this item`)
                 ).toBeInTheDocument();
                 expect(
                     getByText(
-                        `- Max ${mockCategories[0].max_per_team} of items under category ${mockCategories[0].name}`
+                        `- Max ${category.max_per_team} of items under category ${category.name}`
                     )
                 ).toBeInTheDocument();
-                expect(getByText(hardware.model_number)).toBeInTheDocument();
-                expect(getByText(hardware.manufacturer)).toBeInTheDocument();
-                if (hardware.notes)
-                    expect(getByText(hardware.notes)).toBeInTheDocument();
+                expect(getByText(newHardwareData.model_number)).toBeInTheDocument();
+                expect(getByText(newHardwareData.manufacturer)).toBeInTheDocument();
+                if (newHardwareData.notes)
+                    expect(getByText(newHardwareData.notes)).toBeInTheDocument();
             });
         }
     });

--- a/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.test.tsx
@@ -174,9 +174,8 @@ describe("Inventory Page", () => {
 
         fireEvent.click(getByText(mockHardware[0].name));
 
-        // Check if the correct get request was dispatched
         await waitFor(() => {
-            expect(mockedGet).toHaveBeenNthCalledWith(3, hardwareDetailUri);
+            expect(get).toHaveBeenNthCalledWith(3, hardwareDetailUri);
             expect(getByText("Product Overview")).toBeVisible();
             expect(
                 getByText(`- Max ${newHardwareData.max_per_team} of this item`)

--- a/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import Drawer from "@material-ui/core/Drawer";
 import Typography from "@material-ui/core/Typography";
@@ -36,6 +36,7 @@ const Inventory = () => {
     const count = useSelector(hardwareCountSelector);
     const isMoreLoading = useSelector(isMoreLoadingSelector);
     const isLoading = useSelector(isLoadingSelector);
+    const isMounted = useRef(false);
 
     const [mobileOpen, setMobileOpen] = React.useState(false);
     const toggleFilter = () => {
@@ -52,9 +53,12 @@ const Inventory = () => {
 
     // When the page is loaded, clear filters and fetch fresh inventory data
     useEffect(() => {
-        dispatch(clearFilters());
-        dispatch(getHardwareWithFilters());
-        dispatch(getCategories());
+        if (!isMounted.current) {
+            dispatch(clearFilters());
+            dispatch(getHardwareWithFilters());
+            dispatch(getCategories());
+            isMounted.current = true;
+        }
     }, [dispatch]);
 
     return (

--- a/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Inventory/Inventory.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import Drawer from "@material-ui/core/Drawer";
 import Typography from "@material-ui/core/Typography";
@@ -36,7 +36,6 @@ const Inventory = () => {
     const count = useSelector(hardwareCountSelector);
     const isMoreLoading = useSelector(isMoreLoadingSelector);
     const isLoading = useSelector(isLoadingSelector);
-    const isMounted = useRef(false);
 
     const [mobileOpen, setMobileOpen] = React.useState(false);
     const toggleFilter = () => {
@@ -53,12 +52,9 @@ const Inventory = () => {
 
     // When the page is loaded, clear filters and fetch fresh inventory data
     useEffect(() => {
-        if (!isMounted.current) {
-            dispatch(clearFilters());
-            dispatch(getHardwareWithFilters());
-            dispatch(getCategories());
-            isMounted.current = true;
-        }
+        dispatch(clearFilters());
+        dispatch(getHardwareWithFilters());
+        dispatch(getCategories());
     }, [dispatch]);
 
     return (

--- a/hackathon_site/dashboard/frontend/src/slices/hardware/hardwareSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/hardware/hardwareSlice.ts
@@ -174,13 +174,6 @@ const hardwareSlice = createSlice({
             }
         },
 
-        setProductOverviewHardwareId: (
-            state: HardwareState,
-            { payload }: PayloadAction<number>
-        ) => {
-            state.hardwareIdInProductOverview = payload;
-        },
-
         removeProductOverviewItem: (state: HardwareState) => {
             state.hardwareIdInProductOverview = null;
         },
@@ -260,12 +253,7 @@ const hardwareSlice = createSlice({
 export const { actions, reducer } = hardwareSlice;
 export default reducer;
 
-export const {
-    setFilters,
-    clearFilters,
-    setProductOverviewHardwareId,
-    removeProductOverviewItem,
-} = actions;
+export const { setFilters, clearFilters, removeProductOverviewItem } = actions;
 
 // Selectors
 export const hardwareSliceSelector = (state: RootState) => state[hardwareReducerName];

--- a/hackathon_site/dashboard/frontend/src/slices/ui/uiSlice.ts
+++ b/hackathon_site/dashboard/frontend/src/slices/ui/uiSlice.ts
@@ -1,5 +1,4 @@
-import { createSelector, createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { Hardware } from "api/types";
+import { createSelector, createSlice } from "@reduxjs/toolkit";
 import { RootState } from "../store";
 
 // Slice
@@ -10,7 +9,6 @@ interface UIInitialState {
         isPendingTableVisible: boolean;
     };
     inventory: {
-        hardwareItemBeingViewed: Hardware | null;
         isProductOverviewVisible: boolean;
     };
     snackbars: {
@@ -29,7 +27,6 @@ export const initialState: UIInitialState = {
         isPendingTableVisible: true,
     },
     inventory: {
-        hardwareItemBeingViewed: null,
         isProductOverviewVisible: false,
     },
     snackbars: [],
@@ -51,15 +48,10 @@ const uiSlice = createSlice({
             state.dashboard.isPendingTableVisible =
                 !state.dashboard.isPendingTableVisible;
         },
-        setProductOverviewItem: (
-            state: UIState,
-            { payload }: PayloadAction<Hardware>
-        ) => {
-            state.inventory.hardwareItemBeingViewed = payload;
+        openProductOverview: (state: UIState) => {
             state.inventory.isProductOverviewVisible = true;
         },
-        removeProductOverviewItem: (state: UIState) => {
-            state.inventory.hardwareItemBeingViewed = null;
+        closeProductOverview: (state: UIState) => {
             state.inventory.isProductOverviewVisible = false;
         },
         displaySnackbar: (state: UIState, { payload: { message, options = {} } }) => {
@@ -100,8 +92,8 @@ export const {
     toggleCheckedOutTable,
     toggleReturnedTable,
     togglePendingTable,
-    setProductOverviewItem,
-    removeProductOverviewItem,
+    openProductOverview,
+    closeProductOverview,
     displaySnackbar,
     dismissSnackbar,
     removeSnackbar,
@@ -125,10 +117,6 @@ export const isPendingTableVisibleSelector = createSelector(
 export const snackbarSelector = createSelector(
     [uiSliceSelector],
     (uiSlice) => uiSlice.snackbars
-);
-export const hardwareBeingViewedSelector = createSelector(
-    [uiSliceSelector],
-    (uiSlice) => uiSlice.inventory.hardwareItemBeingViewed
 );
 export const isProductOverviewVisibleSelector = createSelector(
     [uiSliceSelector],

--- a/hackathon_site/dashboard/frontend/src/testing/utils.tsx
+++ b/hackathon_site/dashboard/frontend/src/testing/utils.tsx
@@ -135,9 +135,7 @@ export const makeStoreWithEntities = (entities: StoreEntities) => {
         }
 
         preloadedState[hardwareReducerName] = hardwareState;
-    }
-
-    if (entities.hardwareState) {
+    } else if (entities.hardwareState) {
         preloadedState[hardwareReducerName] = {
             ...hardwareInitialState,
             ...entities.hardwareState,


### PR DESCRIPTION
## Overview

- I moved the hardware entity in view to the hardware slice (it used to be in the ui slice) because it's easier to manage that way
- also moved the call for getUpdatedHardwareDetails out of product overview, this saves us a small step of not having to pass the hardware id into product overview but @KarandeepLubana if you don't like this I'll add the useEffect back, I'm still kind of debating which method is better


## Unit Tests Created

- unit tests for product overview & dashboard
- unit tests for hardwareslice for new state


## Steps to QA

- open product overview from dashbaord page (click info icon in checked out items table)
- open product overview from inventory page (click any hardware item)

