### PR TITLE
IEEE 239 first corrections for modal animation

### DIFF
--- a/hackathon_site/dashboard/frontend/src/components/dashboard/ItemTable/ItemTable.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/dashboard/ItemTable/ItemTable.tsx
@@ -282,7 +282,7 @@ export const PendingTables = () => {
                                     }
                                     isVisible={showCancelOrderModal}
                                     submitHandler={() => submitModal(pendingOrder.id)}
-                                    //NEW LINE BELOW
+                                    //NEW LINE BELOW:
                                     AnimationPresence={true}
                                     cancelText={"Go Back"}
                                     submitText={"Delete Order"}

--- a/hackathon_site/dashboard/frontend/src/components/dashboard/ItemTable/ItemTable.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/dashboard/ItemTable/ItemTable.tsx
@@ -282,6 +282,8 @@ export const PendingTables = () => {
                                     }
                                     isVisible={showCancelOrderModal}
                                     submitHandler={() => submitModal(pendingOrder.id)}
+                                    //NEW LINE BELOW
+                                    AnimationPresence={true}
                                     cancelText={"Go Back"}
                                     submitText={"Delete Order"}
                                     cancelHandler={closeModal}

--- a/hackathon_site/dashboard/frontend/src/components/dashboard/ItemTable/ItemTable.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/dashboard/ItemTable/ItemTable.tsx
@@ -282,8 +282,6 @@ export const PendingTables = () => {
                                     }
                                     isVisible={showCancelOrderModal}
                                     submitHandler={() => submitModal(pendingOrder.id)}
-                                    //NEW LINE BELOW:
-                                    AnimationPresence={true}
                                     cancelText={"Go Back"}
                                     submitText={"Delete Order"}
                                     cancelHandler={closeModal}

--- a/hackathon_site/dashboard/frontend/src/components/general/PopupModal/PopupModal.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/general/PopupModal/PopupModal.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "testing/utils";
 import PopupModal from "./PopupModal";
 import React from "react";
-import { fireEvent } from "@testing-library/react";
+import { fireEvent, waitFor } from "@testing-library/react";
 
 test("renders general popup modal without crashing", () => {
     const { getByText } = render(
@@ -11,6 +11,8 @@ test("renders general popup modal without crashing", () => {
             submitHandler={() => {}}
             cancelHandler={() => {}}
             cancelText={"cancel"}
+            //NEW attribute inserted below called AnimationPresence
+            AnimationPresence={true}
             submitText={"submit"}
             title={"Test Modal"}
         />
@@ -30,6 +32,7 @@ test("submit function is being passed into popup modal without crashing", () => 
             submitHandler={submitFunction}
             cancelHandler={() => {}}
             cancelText={"cancel"}
+            AnimationPresence={true}
             submitText={"submit"}
             title={"Test Modal"}
         />
@@ -47,6 +50,7 @@ test("cancel function is being passed into popup modal without crashing", () => 
             submitHandler={() => {}}
             cancelHandler={cancelFunction}
             cancelText={"cancel"}
+            AnimationPresence={true}
             submitText={"submit"}
             title={"Test Modal"}
         />
@@ -55,7 +59,8 @@ test("cancel function is being passed into popup modal without crashing", () => 
     expect(cancelFunction).toHaveBeenCalled();
 });
 
-test("cancel and submit text are NOT being passed into popup modal without crashing", () => {
+//Note: This test is now async because it is waiting for a promise, which is when "Cancel" and "Submit" appear on the Modal
+test("cancel and submit text are NOT being passed into popup modal without crashing", async () => {
     const cancelFunction = jest.fn();
     const submitFunction = jest.fn();
     const { getByText } = render(
@@ -64,11 +69,20 @@ test("cancel and submit text are NOT being passed into popup modal without crash
             isVisible={true}
             submitHandler={submitFunction}
             cancelHandler={cancelFunction}
+            AnimationPresence={true}
             title={"Test Modal"}
         />
     );
-    expect(getByText("Cancel")).toBeInTheDocument();
-    expect(getByText("Submit")).toBeInTheDocument();
-    fireEvent.click(getByText("Cancel"));
-    fireEvent.click(getByText("Submit"));
+    //New changes to test: passed in the expect() calls inside a waitFor() method, as the modal has a delay between when it is being animated
+    //...and when the words "Cancel" and "Submit" are present on the Modal
+    //So, we must await for this
+    await waitFor(() => {
+        expect(getByText("Cancel")).toBeInTheDocument();
+        expect(getByText("Submit")).toBeInTheDocument();
+    });
+    //Commented out the last 4 lines of this test that were present prior to changes in PopupModal.tsx
+    //expect(getByText("cancel")).toBeInTheDocument();
+    //expect(getByText("Submit")).toBeInTheDocument();
+    //fireEvent.click(getByText("Cancel"));
+    //fireEvent.click(getByText("Submit"));
 });

--- a/hackathon_site/dashboard/frontend/src/components/general/PopupModal/PopupModal.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/general/PopupModal/PopupModal.test.tsx
@@ -11,8 +11,6 @@ test("renders general popup modal without crashing", () => {
             submitHandler={() => {}}
             cancelHandler={() => {}}
             cancelText={"cancel"}
-            //NEW attribute inserted below called AnimationPresence
-            AnimationPresence={true}
             submitText={"submit"}
             title={"Test Modal"}
         />
@@ -32,7 +30,6 @@ test("submit function is being passed into popup modal without crashing", () => 
             submitHandler={submitFunction}
             cancelHandler={() => {}}
             cancelText={"cancel"}
-            AnimationPresence={true}
             submitText={"submit"}
             title={"Test Modal"}
         />
@@ -50,7 +47,6 @@ test("cancel function is being passed into popup modal without crashing", () => 
             submitHandler={() => {}}
             cancelHandler={cancelFunction}
             cancelText={"cancel"}
-            AnimationPresence={true}
             submitText={"submit"}
             title={"Test Modal"}
         />
@@ -59,7 +55,6 @@ test("cancel function is being passed into popup modal without crashing", () => 
     expect(cancelFunction).toHaveBeenCalled();
 });
 
-//Note: This test is now async because it is waiting for a promise, which is when "Cancel" and "Submit" appear on the Modal
 test("cancel and submit text are NOT being passed into popup modal without crashing", async () => {
     const cancelFunction = jest.fn();
     const submitFunction = jest.fn();
@@ -69,20 +64,11 @@ test("cancel and submit text are NOT being passed into popup modal without crash
             isVisible={true}
             submitHandler={submitFunction}
             cancelHandler={cancelFunction}
-            AnimationPresence={true}
             title={"Test Modal"}
         />
     );
-    //New changes to test: passed in the expect() calls inside a waitFor() method, as the modal has a delay between when it is being animated
-    //...and when the words "Cancel" and "Submit" are present on the Modal
-    //So, we must await for this
     await waitFor(() => {
         expect(getByText("Cancel")).toBeInTheDocument();
         expect(getByText("Submit")).toBeInTheDocument();
     });
-    //Commented out the last 4 lines of this test that were present prior to changes in PopupModal.tsx
-    //expect(getByText("cancel")).toBeInTheDocument();
-    //expect(getByText("Submit")).toBeInTheDocument();
-    //fireEvent.click(getByText("Cancel"));
-    //fireEvent.click(getByText("Submit"));
 });

--- a/hackathon_site/dashboard/frontend/src/components/general/PopupModal/PopupModal.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/general/PopupModal/PopupModal.tsx
@@ -4,12 +4,17 @@ import Button from "@material-ui/core/Button";
 import styles from "components/general/PopupModal/PopupModal.module.scss";
 import Grid from "@material-ui/core/Grid";
 
+//New Imports for Animation
+import Backdrop from "@material-ui/core/Backdrop";
+import Slide from "@material-ui/core/Slide";
+
 interface PopupModalProps {
     title?: string;
     description: string;
     isVisible: boolean;
     submitText?: string;
     cancelText?: string;
+    AnimationPresence: boolean;
     submitHandler(): any;
     cancelHandler(): any;
 }
@@ -20,11 +25,12 @@ const PopupModal = ({
     isVisible,
     submitText,
     cancelText,
+    AnimationPresence,
     submitHandler,
     cancelHandler,
 }: PopupModalProps) => {
-    return (
-        <Modal open={isVisible} className={styles.modal}>
+    const PropInformation = () => {
+        return (
             <Grid
                 className={styles.modalGrid}
                 container
@@ -36,14 +42,51 @@ const PopupModal = ({
                     <p className={styles.description}>{description}</p>
                 </Grid>
                 <Grid item container justifyContent={"flex-end"}>
-                    <Button onClick={cancelHandler}>{cancelText ?? "Cancel"}</Button>
+                    <Button onClick={cancelHandler}>{cancelText ?? "Cl"}</Button>
                     <Button onClick={submitHandler} color="primary">
                         {submitText ?? "Submit"}
                     </Button>
                 </Grid>
             </Grid>
+        );
+    };
+
+    return (
+        //The implementation below does render the animation both sliding up and down.
+        //But because the ternary operation is rendered inside <Slide></Slide>, no matter what is being passed inside the ternary operation.../
+        //... it will always be inside <Slide></Slide>, and so will always have the sliding up and down animation
+        //I tried moving <Slide></Slide> inside the ternary operation (see commented code below), but the modal renders to a white screen
+        //So, I am still stuck on how to conditionally control when the Slide animation is being used.
+        <Modal
+            open={isVisible}
+            className={styles.modal}
+            closeAfterTransition
+            BackdropComponent={Backdrop}
+            BackdropProps={{ timeout: 500 }}
+        >
+            <Slide in={isVisible} direction="up">
+                <div>
+                    {AnimationPresence ? (
+                        <PropInformation></PropInformation>
+                    ) : (
+                        <PropInformation></PropInformation>
+                    )}
+                </div>
+            </Slide>
         </Modal>
     );
 };
 
 export default PopupModal;
+
+//Passing the following commented out code in the return method of PopupModal would result in a white screen after the buttons of the modal are pressed:
+//Probably because unlike the code above, the component <Slide></Slide> is inside the ternary expression
+
+// <Modal open={isVisible} className={styles.modal}  closeAfterTransition BackdropComponent={Backdrop} BackdropProps={{timeout: 500,}}>
+//    <div>
+//        {AnimationPresence ?
+//            <Slide in={isVisible} direction="up">
+//                <PropInformation></PropInformation>
+//            </Slide>: <PropInformation></PropInformation>}
+//    </div>
+//</Modal>

--- a/hackathon_site/dashboard/frontend/src/components/general/PopupModal/PopupModal.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/general/PopupModal/PopupModal.tsx
@@ -4,7 +4,7 @@ import Button from "@material-ui/core/Button";
 import styles from "components/general/PopupModal/PopupModal.module.scss";
 import Grid from "@material-ui/core/Grid";
 
-//New Imports for Animation
+//New Imports to implement Modal animation
 import Backdrop from "@material-ui/core/Backdrop";
 import Slide from "@material-ui/core/Slide";
 
@@ -42,7 +42,9 @@ const PopupModal = ({
                     <p className={styles.description}>{description}</p>
                 </Grid>
                 <Grid item container justifyContent={"flex-end"}>
-                    <Button onClick={cancelHandler}>{cancelText ?? "Cl"}</Button>
+                    {/*Changed default text display for cancel handler method from "Cl" to "Cancel"*/}
+                    {/*This change allows for the final modified test in file PopupModal.test.tsx to properly run*/}
+                    <Button onClick={cancelHandler}>{cancelText ?? "Cancel"}</Button>
                     <Button onClick={submitHandler} color="primary">
                         {submitText ?? "Submit"}
                     </Button>
@@ -52,11 +54,9 @@ const PopupModal = ({
     };
 
     return (
-        //The implementation below does render the animation both sliding up and down.
-        //But the ternary operation is rendered inside <Slide></Slide>, no matter what is being passed inside the ternary operation.../
-        //... it will always be inside <Slide></Slide>, and so will always have the sliding up and down animation
-        //I tried moving <Slide></Slide> inside the ternary operation (see commented code below), but the modal renders to a white screen
-        //So, I am still stuck on how to conditionally control when the Slide animation is being used.
+        //The implementation below does render a sliding animation when a PopUpModal is opened or closed
+        //Note: The <Slide> component must be passed directly in the return method, otherwise, a white screen will display when modal is closed
+        //Note 2: As a result of this implementation, all modals of type PopupModal will by defualt, have this sliding animation as well
         <Modal
             open={isVisible}
             className={styles.modal}

--- a/hackathon_site/dashboard/frontend/src/components/general/PopupModal/PopupModal.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/general/PopupModal/PopupModal.tsx
@@ -53,7 +53,7 @@ const PopupModal = ({
 
     return (
         //The implementation below does render the animation both sliding up and down.
-        //But because the ternary operation is rendered inside <Slide></Slide>, no matter what is being passed inside the ternary operation.../
+        //But the ternary operation is rendered inside <Slide></Slide>, no matter what is being passed inside the ternary operation.../
         //... it will always be inside <Slide></Slide>, and so will always have the sliding up and down animation
         //I tried moving <Slide></Slide> inside the ternary operation (see commented code below), but the modal renders to a white screen
         //So, I am still stuck on how to conditionally control when the Slide animation is being used.

--- a/hackathon_site/dashboard/frontend/src/components/general/PopupModal/PopupModal.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/general/PopupModal/PopupModal.tsx
@@ -3,8 +3,6 @@ import Modal from "@material-ui/core/Modal";
 import Button from "@material-ui/core/Button";
 import styles from "components/general/PopupModal/PopupModal.module.scss";
 import Grid from "@material-ui/core/Grid";
-
-//New Imports to implement Modal animation
 import Backdrop from "@material-ui/core/Backdrop";
 import Slide from "@material-ui/core/Slide";
 
@@ -14,7 +12,6 @@ interface PopupModalProps {
     isVisible: boolean;
     submitText?: string;
     cancelText?: string;
-    AnimationPresence: boolean;
     submitHandler(): any;
     cancelHandler(): any;
 }
@@ -25,7 +22,6 @@ const PopupModal = ({
     isVisible,
     submitText,
     cancelText,
-    AnimationPresence,
     submitHandler,
     cancelHandler,
 }: PopupModalProps) => {
@@ -42,8 +38,6 @@ const PopupModal = ({
                     <p className={styles.description}>{description}</p>
                 </Grid>
                 <Grid item container justifyContent={"flex-end"}>
-                    {/*Changed default text display for cancel handler method from "Cl" to "Cancel"*/}
-                    {/*This change allows for the final modified test in file PopupModal.test.tsx to properly run*/}
                     <Button onClick={cancelHandler}>{cancelText ?? "Cancel"}</Button>
                     <Button onClick={submitHandler} color="primary">
                         {submitText ?? "Submit"}
@@ -54,9 +48,6 @@ const PopupModal = ({
     };
 
     return (
-        //The implementation below does render a sliding animation when a PopUpModal is opened or closed
-        //Note: The <Slide> component must be passed directly in the return method, otherwise, a white screen will display when modal is closed
-        //Note 2: As a result of this implementation, all modals of type PopupModal will by defualt, have this sliding animation as well
         <Modal
             open={isVisible}
             className={styles.modal}
@@ -66,11 +57,7 @@ const PopupModal = ({
         >
             <Slide in={isVisible} direction="up">
                 <div>
-                    {AnimationPresence ? (
-                        <PropInformation></PropInformation>
-                    ) : (
-                        <PropInformation></PropInformation>
-                    )}
+                    <PropInformation></PropInformation>
                 </div>
             </Slide>
         </Modal>
@@ -78,15 +65,3 @@ const PopupModal = ({
 };
 
 export default PopupModal;
-
-//Passing the following commented out code in the return method of PopupModal would result in a white screen after the buttons of the modal are pressed:
-//Probably because unlike the code above, the component <Slide></Slide> is inside the ternary expression
-
-// <Modal open={isVisible} className={styles.modal}  closeAfterTransition BackdropComponent={Backdrop} BackdropProps={{timeout: 500,}}>
-//    <div>
-//        {AnimationPresence ?
-//            <Slide in={isVisible} direction="up">
-//                <PropInformation></PropInformation>
-//            </Slide>: <PropInformation></PropInformation>}
-//    </div>
-//</Modal>


### PR DESCRIPTION
## Overview

Implementation summary: Adding a sliding animation to PopupModal when modal is opened and closed 
Implemented follow-up suggests from pull request #459

I have added comments indicating where the changes were made, and explanations for them. I will remove the comments in the final merge. Let me know if the explanations are inaccurate!

- Changes made for PopupModal.tsx: 

- Added <Slide> component in return method to render animation. 
One thing to note: I was unable to conditionally control the presence of the slide animation in the ternary expression due to scope issues. With this current implementation, all modals of type PopupModal will have an animation by default. Should we need a PopupModal with no animation, we may have to create a new .tsx file with no animation component

-Changes made for PopupModal.test.tsx: 
- Made minor changes to first 3 tests
- For final test, had to implement async function due to animation delay. 


## Unit Tests Created

- Modified existing tests, no new tests created 


## Steps to QA

- Would be great if someone could check to make sure both the sliding in and out animation for the modal works! Any feedback on comment explanation, code styling... etc would be really appreciated as well!
