### PR TITLE
added validation for review decision sent_date

### DIFF
--- a/hackathon_site/event/serializers.py
+++ b/hackathon_site/event/serializers.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.contrib.auth.models import Group
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
@@ -116,12 +118,16 @@ class CurrentProfileSerializer(ProfileSerializer):
                 )
 
             try:
-                review_status = Review.objects.get(
+                review = Review.objects.get(
                     application__user=current_user
-                ).status
-                if review_status != "Accepted":
+                )
+                if review.status != "Accepted":
                     raise serializers.ValidationError(
                         f"User has not been accepted to participate in {settings.HACKATHON_NAME}"
+                    )
+                if review.decision_sent_date is None:
+                    raise serializers.ValidationError(
+                        "User has not been reviewed yet, Hardware Signout Site cannot be accessed until reviewed"
                     )
             except Review.DoesNotExist:
                 raise serializers.ValidationError(
@@ -187,6 +193,7 @@ class UserReviewStatusSerializer(serializers.ModelSerializer):
     @staticmethod
     def get_review_status(user: User):
         try:
-            return Review.objects.get(application__user=user).status
+            review = Review.objects.get(application__user=user)
+            return review.status if review.decision_sent_date is not None else "None"
         except ObjectDoesNotExist:
             return "None"

--- a/hackathon_site/event/serializers.py
+++ b/hackathon_site/event/serializers.py
@@ -118,9 +118,7 @@ class CurrentProfileSerializer(ProfileSerializer):
                 )
 
             try:
-                review = Review.objects.get(
-                    application__user=current_user
-                )
+                review = Review.objects.get(application__user=current_user)
                 if review.status != "Accepted":
                     raise serializers.ValidationError(
                         f"User has not been accepted to participate in {settings.HACKATHON_NAME}"

--- a/hackathon_site/event/test_api.py
+++ b/hackathon_site/event/test_api.py
@@ -646,7 +646,8 @@ class CreateProfileViewTestCase(SetupUserMixin, APITestCase):
 
     def test_user_has_been_reviewed_but_not_sent(self):
         self._review(
-            application=self._apply_as_user(self.user, rsvp=True), decision_sent_date=None
+            application=self._apply_as_user(self.user, rsvp=True),
+            decision_sent_date=None,
         )
         self._login()
         response = self.client.post(self.view, self.request_body)

--- a/hackathon_site/event/test_api.py
+++ b/hackathon_site/event/test_api.py
@@ -644,6 +644,19 @@ class CreateProfileViewTestCase(SetupUserMixin, APITestCase):
             "User has not been reviewed yet, Hardware Signout Site cannot be accessed until reviewed",
         )
 
+    def test_user_has_been_reviewed_but_not_sent(self):
+        self._review(
+            application=self._apply_as_user(self.user, rsvp=True), decision_sent_date=None
+        )
+        self._login()
+        response = self.client.post(self.view, self.request_body)
+        data = response.json()
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            data[0],
+            "User has not been reviewed yet, Hardware Signout Site cannot be accessed until reviewed",
+        )
+
     def test_user_review_rejected(self):
         self._review(
             application=self._apply_as_user(self.user, rsvp=True), status="Rejected"

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -997,9 +997,7 @@ class UserReviewStatusSerializerTestCase(SetupUserMixin, TestCase):
         self.assertEqual(user_expected, user_serialized)
 
     def test_serializer_review_but_not_sent(self):
-        self._review(
-            application=self.application, decision_sent_date=None
-        )
+        self._review(application=self.application, decision_sent_date=None)
         user_serialized = UserReviewStatusSerializer(self.user).data
 
         user_expected = {

--- a/hackathon_site/event/tests.py
+++ b/hackathon_site/event/tests.py
@@ -995,3 +995,19 @@ class UserReviewStatusSerializerTestCase(SetupUserMixin, TestCase):
         }
 
         self.assertEqual(user_expected, user_serialized)
+
+    def test_serializer_review_but_not_sent(self):
+        self._review(
+            application=self.application, decision_sent_date=None
+        )
+        user_serialized = UserReviewStatusSerializer(self.user).data
+
+        user_expected = {
+            "id": self.user.id,
+            "first_name": self.user.first_name,
+            "last_name": self.user.last_name,
+            "email": self.user.email,
+            "review_status": "None",
+        }
+
+        self.assertEqual(user_expected, user_serialized)

--- a/hackathon_site/registration/test_views.py
+++ b/hackathon_site/registration/test_views.py
@@ -366,7 +366,8 @@ class RSVPViewTestCase(SetupUserMixin, TestCase):
         self.user.application.refresh_from_db()
 
         self.assertTrue(self.user.application.rsvp)
-        self.assertTrue(hasattr(self.user, "profile"))
+        # TODO: decide whether to create profile when rsvp
+        # self.assertTrue(hasattr(self.user, "profile"))
         self.assertRedirects(response, reverse("event:dashboard"))
 
     def test_redirects_to_dashboard_if_rsvp_deadline_passed(self):

--- a/hackathon_site/registration/views.py
+++ b/hackathon_site/registration/views.py
@@ -260,8 +260,9 @@ class RSVPView(LoginRequiredMixin, View):
                 application.rsvp = True
                 application.save()
 
-                profile = Profile(user=user, team=EventTeam.objects.create())
-                profile.save()
+                # TODO: decide whether to create profile when rsvp
+                # profile = Profile(user=user, team=EventTeam.objects.create())
+                # profile.save()
 
             elif decision == "no" and (application.rsvp or application.rsvp is None):
                 application.rsvp = False


### PR DESCRIPTION
## Overview

- added a check that only allows users to create profiles after acceptances have been sent out
- fix rsvp bug


## Unit Tests Created

- edited user review and create profile serializers


## Steps to QA

- apply as a (new) user
- accept user to hackathon (but not change decision-sent-date)
- go to HSS, you should be unable to create a profile/view acknowledgements page

