### PR TITLE
Call getOrdersWithFilters Thunk when refresh button clicked

### DIFF
--- a/hackathon_site/dashboard/frontend/src/components/orders/OrdersCount/OrdersCount.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/orders/OrdersCount/OrdersCount.tsx
@@ -6,7 +6,7 @@ import styles from "pages/Orders/Orders.module.scss";
 import {
     adminOrderTotalSelector,
     getOrdersWithFilters,
-} from "../../../slices/order/adminOrderSlice";
+} from "slices/order/adminOrderSlice";
 
 const OrdersCount = () => {
     const dispatch = useDispatch();

--- a/hackathon_site/dashboard/frontend/src/components/orders/OrdersCount/OrdersCount.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/orders/OrdersCount/OrdersCount.tsx
@@ -1,12 +1,18 @@
 import React from "react";
 import { IconButton, Typography } from "@material-ui/core";
 import RefreshIcon from "@material-ui/icons/Refresh";
-import { useSelector } from "react-redux";
-import { FormikValues } from "formik";
+import { useDispatch, useSelector } from "react-redux";
 import styles from "pages/Orders/Orders.module.scss";
-import { adminOrderTotalSelector } from "../../../slices/order/adminOrderSlice";
+import {
+    adminOrderTotalSelector,
+    getOrdersWithFilters,
+} from "../../../slices/order/adminOrderSlice";
 
-const OrdersCount = ({ refreshOrders }: FormikValues) => {
+const OrdersCount = () => {
+    const dispatch = useDispatch();
+    const refreshOrders = () => {
+        dispatch(getOrdersWithFilters());
+    };
     const orderQuantity = useSelector(adminOrderTotalSelector);
     return (
         <div className={styles.ordersBodyToolbarRefresh}>

--- a/hackathon_site/dashboard/frontend/src/pages/Orders/Orders.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Orders/Orders.test.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import {render, within} from "testing/utils";
-import {mockHardware, mockPendingOrders} from "testing/mockData";
+import { render, within } from "testing/utils";
+import { mockHardware, mockPendingOrders } from "testing/mockData";
 import Orders from "./Orders";
-import {RootStore} from "slices/store";
-import {makeStoreWithEntities} from "testing/utils";
+import { RootStore } from "slices/store";
+import { makeStoreWithEntities } from "testing/utils";
 
 describe("Orders Page", () => {
     let store: RootStore;
@@ -15,14 +15,14 @@ describe("Orders Page", () => {
         });
     });
     test("Has necessary page elements", () => {
-        const {getByText, getByTestId} = render(<Orders/>, {store});
+        const { getByText, getByTestId } = render(<Orders />, { store });
 
         expect(getByText("Orders")).toBeInTheDocument();
         expect(getByTestId("ordersCountDivider")).toBeInTheDocument();
     });
 
     test("Display correct order cards", () => {
-        const {getByTestId} = render(<Orders/>, {store});
+        const { getByTestId } = render(<Orders />, { store });
         mockPendingOrders.forEach((order) => {
             const orderStatus = order.status;
 
@@ -30,7 +30,7 @@ describe("Orders Page", () => {
                 const orderItem = getByTestId(`order-item-${order.id}`);
                 const orderDetails = within(orderItem);
                 const date = new Date(order.created_at);
-                const month = date.toLocaleString("default", {month: "short"});
+                const month = date.toLocaleString("default", { month: "short" });
                 const day = date.getDate();
                 const hoursAndMinutes = date.getHours() + ":" + date.getMinutes();
 
@@ -50,10 +50,9 @@ describe("Orders Page", () => {
         });
     });
     test("Display correct amount of order results", () => {
-        const {getByText, getByTestId} = render(<Orders/>, {store});
+        const { getByText, getByTestId } = render(<Orders />, { store });
         const orderCount = mockPendingOrders.length;
         const resultText = getByText(`${orderCount} results`);
         expect(resultText).toBeInTheDocument();
     });
-
 });

--- a/hackathon_site/dashboard/frontend/src/pages/Orders/Orders.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Orders/Orders.test.tsx
@@ -49,4 +49,11 @@ describe("Orders Page", () => {
             // }
         });
     });
+    test("Display correct amount of order results", ()=>{
+        const { getByText, getByTestId } = render(<Orders />, { store });
+        const orderCount = mockPendingOrders.length;
+         const resultText = getByText(`${orderCount} results`);
+         expect(resultText).toBeInTheDocument();
+    });
+
 });

--- a/hackathon_site/dashboard/frontend/src/pages/Orders/Orders.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Orders/Orders.test.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { render, within } from "testing/utils";
-import { mockHardware, mockPendingOrders } from "testing/mockData";
+import {render, within} from "testing/utils";
+import {mockHardware, mockPendingOrders} from "testing/mockData";
 import Orders from "./Orders";
-import { RootStore } from "slices/store";
-import { makeStoreWithEntities } from "testing/utils";
+import {RootStore} from "slices/store";
+import {makeStoreWithEntities} from "testing/utils";
 
 describe("Orders Page", () => {
     let store: RootStore;
@@ -15,14 +15,14 @@ describe("Orders Page", () => {
         });
     });
     test("Has necessary page elements", () => {
-        const { getByText, getByTestId } = render(<Orders />, { store });
+        const {getByText, getByTestId} = render(<Orders/>, {store});
 
         expect(getByText("Orders")).toBeInTheDocument();
         expect(getByTestId("ordersCountDivider")).toBeInTheDocument();
     });
 
     test("Display correct order cards", () => {
-        const { getByTestId } = render(<Orders />, { store });
+        const {getByTestId} = render(<Orders/>, {store});
         mockPendingOrders.forEach((order) => {
             const orderStatus = order.status;
 
@@ -30,7 +30,7 @@ describe("Orders Page", () => {
                 const orderItem = getByTestId(`order-item-${order.id}`);
                 const orderDetails = within(orderItem);
                 const date = new Date(order.created_at);
-                const month = date.toLocaleString("default", { month: "short" });
+                const month = date.toLocaleString("default", {month: "short"});
                 const day = date.getDate();
                 const hoursAndMinutes = date.getHours() + ":" + date.getMinutes();
 
@@ -49,11 +49,11 @@ describe("Orders Page", () => {
             // }
         });
     });
-    test("Display correct amount of order results", ()=>{
-        const { getByText, getByTestId } = render(<Orders />, { store });
+    test("Display correct amount of order results", () => {
+        const {getByText, getByTestId} = render(<Orders/>, {store});
         const orderCount = mockPendingOrders.length;
-         const resultText = getByText(`${orderCount} results`);
-         expect(resultText).toBeInTheDocument();
+        const resultText = getByText(`${orderCount} results`);
+        expect(resultText).toBeInTheDocument();
     });
 
 });

--- a/hackathon_site/dashboard/frontend/src/pages/Orders/Orders.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/pages/Orders/Orders.test.tsx
@@ -50,7 +50,7 @@ describe("Orders Page", () => {
         });
     });
     test("Display correct amount of order results", () => {
-        const { getByText, getByTestId } = render(<Orders />, { store });
+        const { getByText } = render(<Orders />, { store });
         const orderCount = mockPendingOrders.length;
         const resultText = getByText(`${orderCount} results`);
         expect(resultText).toBeInTheDocument();


### PR DESCRIPTION
## Overview

- Resolves 243 Redux: Refetch orders when click on refresh button Orders Page (Admin Side)
- The refresh button gets the correct number of orders by calling the getOrdersWithFilters thunk


## Unit Tests Created

Front end test to ensure expected order count is displayed on order page


## Steps to QA

- <Steps for a reviewer to QA your work> 

