### PR TITLE
IEEE 215 *new* checked out order card

### DIFF
--- a/hackathon_site/dashboard/frontend/src/components/orders/OrderCard/OrderPending.module.scss
+++ b/hackathon_site/dashboard/frontend/src/components/orders/OrderCard/OrderPending.module.scss
@@ -1,0 +1,23 @@
+@import "../../../assets/abstracts/mixins";
+@import "../../../assets/abstracts/variables";
+
+.container {
+    padding: 12px 4px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    min-height: 160px;
+}
+
+.contentContainer {
+    display: flex;
+    justify-content: space-between;
+    padding-bottom: 4px;
+    padding-top: 4px;
+}
+
+.title {
+    font-weight: 500;
+    font-style: normal;
+    font-size: 14px;
+}

--- a/hackathon_site/dashboard/frontend/src/components/orders/OrderCard/OrderPending.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/orders/OrderCard/OrderPending.test.tsx
@@ -22,13 +22,12 @@ describe("<OrderPending />", () => {
             { title: "Team", value: teamCode },
             { title: "Order Qty", value: orderQuantity },
             { title: "Time ordered", value: `${month} ${day}, ${hoursAndMinutes}` },
-            // { title: "Received IDs", value: receivedIDs },
             { title: "ID", value: id },
         ];
 
         const { getByText } = render(
             <OrderPending
-                team={teamCode}
+                team_code={teamCode}
                 orderQuantity={orderQuantity}
                 timeOrdered={time}
                 receivedIDs={receivedIDs}

--- a/hackathon_site/dashboard/frontend/src/components/orders/OrderCard/OrderPending.test.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/orders/OrderCard/OrderPending.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { render } from "testing/utils";
+import { mockPendingOrders } from "testing/mockData";
+import OrderPending from "./OrderPending";
+
+describe("<OrderPending />", () => {
+    test("renders order pending card without crashing", () => {
+        const teamCode = mockPendingOrders[1].team_code;
+        const orderQuantity = mockPendingOrders[1].items.length;
+        const time = new Date(mockPendingOrders[1].created_at).toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+        });
+        const id = mockPendingOrders[1].id;
+        const receivedIDs = true;
+        const date = new Date(time);
+        const month = date.toLocaleString("default", { month: "short" });
+        const day = date.getDate();
+        const hoursAndMinutes = date.getHours() + ":" + date.getMinutes();
+
+        const orderDetails = [
+            { title: "Team", value: teamCode },
+            { title: "Order Qty", value: orderQuantity },
+            { title: "Time ordered", value: `${month} ${day}, ${hoursAndMinutes}` },
+            // { title: "Received IDs", value: receivedIDs },
+            { title: "ID", value: id },
+        ];
+
+        const { getByText } = render(
+            <OrderPending
+                team={teamCode}
+                orderQuantity={orderQuantity}
+                timeOrdered={time}
+                receivedIDs={receivedIDs}
+                id={id}
+            />
+        );
+        orderDetails.forEach((item) => {
+            expect(getByText(item.title)).toBeInTheDocument();
+            expect(getByText(item.value.toString())).toBeInTheDocument();
+        });
+    });
+});

--- a/hackathon_site/dashboard/frontend/src/components/orders/OrderCard/OrderPending.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/orders/OrderCard/OrderPending.tsx
@@ -1,0 +1,140 @@
+import React, { useEffect, useState } from "react";
+import styles from "./OrderCardPending.module.scss";
+import { Typography, Container, Card } from "@material-ui/core";
+import { Formik, FormikValues } from "formik";
+import Checkbox from "@material-ui/core/Checkbox";
+import Button from "@material-ui/core/Button";
+import stylesButton from "components/sharedStyles/Filter.module.scss";
+
+interface OrderPendingProps {
+    team: string;
+    orderQuantity: number;
+    timeOrdered: string;
+    receivedIDs: boolean;
+    id: number;
+}
+
+const OrderPending = ({
+    team,
+    orderQuantity,
+    timeOrdered,
+    receivedIDs,
+    id,
+}: OrderPendingProps) => {
+    const date = new Date(timeOrdered);
+    const month = date.toLocaleString("default", { month: "short" });
+    const day = date.getDate();
+    const hoursAndMinutes = date.getHours() + ":" + date.getMinutes();
+
+    const orderDetails = [
+        { title: "Team", value: team },
+        { title: "Order Qty", value: orderQuantity },
+        { title: "Time ordered", value: `${month} ${day}, ${hoursAndMinutes}` },
+        { title: "Received IDs", value: receivedIDs },
+        { title: "ID", value: id },
+    ];
+
+    // controls the state of the button
+    const [pickedUp, setPickedUp] = useState(false);
+
+    const alertEvent = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+        event.preventDefault();
+        if (event.target === event.currentTarget) {
+            alert("The order you clicked is: #" + id);
+        }
+    };
+
+    return (
+        <Card onClick={alertEvent}>
+            <Formik
+                initialValues={{
+                    ReceivedIDsCheck: false,
+                }}
+                onSubmit={(values: FormikValues) => {
+                    console.log(values);
+                    console.log("click picked up");
+                    setPickedUp(true);
+                }}
+            >
+                <Container
+                    className={styles.container}
+                    data-testid={`order-item-${id}`}
+                >
+                    {orderDetails.map((item, idx) => {
+                        return (
+                            <Container
+                                className={styles.contentContainer}
+                                key={idx}
+                                style={{ alignItems: "center" }}
+                            >
+                                <Typography variant="body2" className={styles.title}>
+                                    {item.title}
+                                </Typography>
+                                {item.title === "Received IDs" ? (
+                                    <Checkbox
+                                        name="ReceivedIDsCheck"
+                                        color="primary"
+                                        checked={
+                                            typeof item.value === "boolean"
+                                                ? item.value
+                                                : false
+                                        }
+                                        disabled={pickedUp}
+                                    />
+                                ) : (
+                                    <Typography
+                                        variant="body2"
+                                        style={{ textAlign: "end" }}
+                                    >
+                                        {item.value}
+                                    </Typography>
+                                )}
+                            </Container>
+                        );
+                    })}
+                    <div
+                        style={{
+                            display: "flex",
+                            flexDirection: "row",
+                            justifyContent: "space-between",
+                            alignItems: "center",
+                            padding: "4px 12px",
+                        }}
+                    >
+                        <Button
+                            type="submit"
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                // console.log("click picked up");
+                                setPickedUp(true);
+                            }}
+                            color="primary"
+                            variant="contained"
+                            fullWidth={true}
+                            className={stylesButton.filterBtnsApply}
+                            disabled={pickedUp}
+                            disableElevation
+                            data-testid="apply-button"
+                            style={pickedUp ? { pointerEvents: "none" } : {}}
+                        >
+                            Picked Up
+                        </Button>
+                        <Button
+                            // type="submit"
+                            color="primary"
+                            data-testid="clear-button"
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                console.log("click view");
+                            }}
+                        >
+                            View
+                        </Button>
+                    </div>
+                </Container>
+            </Formik>
+        </Card>
+    );
+};
+
+export default OrderPending;

--- a/hackathon_site/dashboard/frontend/src/components/orders/OrderCard/OrderPending.tsx
+++ b/hackathon_site/dashboard/frontend/src/components/orders/OrderCard/OrderPending.tsx
@@ -7,7 +7,7 @@ import Button from "@material-ui/core/Button";
 import stylesButton from "components/sharedStyles/Filter.module.scss";
 
 interface OrderPendingProps {
-    team: string;
+    team_code: string;
     orderQuantity: number;
     timeOrdered: string;
     receivedIDs: boolean;
@@ -15,7 +15,7 @@ interface OrderPendingProps {
 }
 
 const OrderPending = ({
-    team,
+    team_code,
     orderQuantity,
     timeOrdered,
     receivedIDs,
@@ -27,7 +27,7 @@ const OrderPending = ({
     const hoursAndMinutes = date.getHours() + ":" + date.getMinutes();
 
     const orderDetails = [
-        { title: "Team", value: team },
+        { title: "Team", value: team_code },
         { title: "Order Qty", value: orderQuantity },
         { title: "Time ordered", value: `${month} ${day}, ${hoursAndMinutes}` },
         { title: "Received IDs", value: receivedIDs },
@@ -51,8 +51,6 @@ const OrderPending = ({
                     ReceivedIDsCheck: false,
                 }}
                 onSubmit={(values: FormikValues) => {
-                    console.log(values);
-                    console.log("click picked up");
                     setPickedUp(true);
                 }}
             >
@@ -105,7 +103,6 @@ const OrderPending = ({
                             type="submit"
                             onClick={(event) => {
                                 event.stopPropagation();
-                                // console.log("click picked up");
                                 setPickedUp(true);
                             }}
                             color="primary"
@@ -120,12 +117,10 @@ const OrderPending = ({
                             Picked Up
                         </Button>
                         <Button
-                            // type="submit"
                             color="primary"
                             data-testid="clear-button"
                             onClick={(event) => {
                                 event.stopPropagation();
-                                console.log("click view");
                             }}
                         >
                             View


### PR DESCRIPTION
## Overview

- Resolves 215 Create Checked Out/Picked Up Order Card
- Had some issues with running test so made a new branch from #415
- New order card called `OrderPending`
  - clickable order card that evokes an alert event with the order ID displayed
  - adding picked up and view buttons
  - once picked up is clicked, button is diabled along with the checkbox
- Note: changes from another member are attached to this branch

## Unit Tests Created

- front end test to make sure details are displayed on card


## Steps to QA

- use the mockPendingOrders from mock data and call the OrderPending component in the Orders page instead of allOrders
- clicking on the card will evoke the alert
- clicking on picked up disables itself and the checkbox

![image](https://github.com/ieeeuoft/hackathon-template/assets/86009011/2327d7c4-b86d-4bd8-9081-ccf918b037d9)

